### PR TITLE
feat/#9: Jackson 직렬화/역직렬화 모듈 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.mysql:mysql-connector-j'
 
+    // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok:'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
 import com.almondia.meca.common.domain.vo.configuration.jackson.module.date.LocalDateTimeModule;
+import com.almondia.meca.common.domain.vo.configuration.jackson.module.wrapper.WrapperModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
@@ -16,6 +17,7 @@ public class JacksonConfiguration {
 	public ObjectMapper getObjectMapper() {
 		return new ObjectMapper()
 			.registerModule(new LocalDateTimeModule())
+			.registerModule(new WrapperModule())
 			.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
 	}
 }

--- a/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
+import com.almondia.meca.common.domain.vo.configuration.jackson.module.date.LocalDateTimeModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
@@ -14,6 +15,7 @@ public class JacksonConfiguration {
 	@Primary
 	public ObjectMapper getObjectMapper() {
 		return new ObjectMapper()
+			.registerModule(new LocalDateTimeModule())
 			.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
 	}
 }

--- a/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfiguration.java
@@ -1,0 +1,19 @@
+package com.almondia.meca.common.domain.vo.configuration.jackson;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+@Configuration
+public class JacksonConfiguration {
+
+	@Bean
+	@Primary
+	public ObjectMapper getObjectMapper() {
+		return new ObjectMapper()
+			.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
+	}
+}

--- a/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/date/LocalDateTimeDeserializer.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/date/LocalDateTimeDeserializer.java
@@ -1,0 +1,26 @@
+package com.almondia.meca.common.domain.vo.configuration.jackson.module.date;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+public class LocalDateTimeDeserializer extends StdDeserializer<LocalDateTime> {
+
+	protected LocalDateTimeDeserializer() {
+		this(null);
+	}
+
+	protected LocalDateTimeDeserializer(Class<?> vc) {
+		super(vc);
+	}
+
+	@Override
+	public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt)
+		throws IOException {
+		return LocalDateTime.parse(p.getText(), DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+	}
+}

--- a/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/date/LocalDateTimeModule.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/date/LocalDateTimeModule.java
@@ -2,6 +2,7 @@ package com.almondia.meca.common.domain.vo.configuration.jackson.module.date;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.databind.module.SimpleDeserializers;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.module.SimpleSerializers;
 
@@ -17,6 +18,10 @@ public class LocalDateTimeModule extends SimpleModule {
 		SimpleSerializers simpleSerializers = new SimpleSerializers();
 		simpleSerializers.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
 
+		SimpleDeserializers simpleDeserializers = new SimpleDeserializers();
+		simpleDeserializers.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
+
 		context.addSerializers(simpleSerializers);
+		context.addDeserializers(simpleDeserializers);
 	}
 }

--- a/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/date/LocalDateTimeModule.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/date/LocalDateTimeModule.java
@@ -1,0 +1,22 @@
+package com.almondia.meca.common.domain.vo.configuration.jackson.module.date;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.module.SimpleSerializers;
+
+public class LocalDateTimeModule extends SimpleModule {
+
+	@Override
+	public String getModuleName() {
+		return super.getModuleName();
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		SimpleSerializers simpleSerializers = new SimpleSerializers();
+		simpleSerializers.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
+
+		context.addSerializers(simpleSerializers);
+	}
+}

--- a/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/date/LocalDateTimeSerializer.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/date/LocalDateTimeSerializer.java
@@ -1,0 +1,27 @@
+package com.almondia.meca.common.domain.vo.configuration.jackson.module.date;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class LocalDateTimeSerializer extends StdSerializer<LocalDateTime> {
+
+	protected LocalDateTimeSerializer() {
+		this(null);
+	}
+
+	protected LocalDateTimeSerializer(Class<LocalDateTime> t) {
+		super(t);
+	}
+
+	@Override
+	public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider provider)
+		throws IOException {
+		String format = value.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+		gen.writeString(format);
+	}
+}

--- a/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/wrapper/Wrapper.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/wrapper/Wrapper.java
@@ -1,0 +1,9 @@
+package com.almondia.meca.common.domain.vo.configuration.jackson.module.wrapper;
+
+/**
+ * Wrapper 클래스는 Jackson을 활용해 원시 타입, 또는 문자열과 같은 타입으로 인식할 수 있도록 직렬화를 수행하는데
+ * 선언할 타입이다. 한 개의 인스턴스만 선언해야 하고 이를 지키지 않으면 jackson Serializer는 동작하지 않는다.
+ */
+public interface Wrapper {
+
+}

--- a/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/wrapper/WrapperModule.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/wrapper/WrapperModule.java
@@ -1,0 +1,20 @@
+package com.almondia.meca.common.domain.vo.configuration.jackson.module.wrapper;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.module.SimpleSerializers;
+
+public class WrapperModule extends SimpleModule {
+
+	@Override
+	public String getModuleName() {
+		return super.getModuleName();
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		SimpleSerializers simpleSerializers = new SimpleSerializers();
+		simpleSerializers.addSerializer(Wrapper.class, new WrapperSerializer());
+
+		context.addSerializers(simpleSerializers);
+	}
+}

--- a/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/wrapper/WrapperSerializer.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/configuration/jackson/module/wrapper/WrapperSerializer.java
@@ -1,0 +1,58 @@
+package com.almondia.meca.common.domain.vo.configuration.jackson.module.wrapper;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class WrapperSerializer extends StdSerializer<Wrapper> {
+
+	protected WrapperSerializer() {
+		this(null);
+	}
+
+	protected WrapperSerializer(Class<Wrapper> t) {
+		super(t);
+	}
+
+	@Override
+	public void serialize(Wrapper value, JsonGenerator gen, SerializerProvider provider)
+		throws IOException {
+		Class<?> clazz = value.getClass();
+		Field[] fields = clazz.getDeclaredFields();
+		if (fields.length != 1) {
+			throw new IllegalStateException();
+		}
+		Field field = fields[0];
+		field.setAccessible(true);
+		makeJsonByFieldType(value, gen, field);
+	}
+
+	private void makeJsonByFieldType(Wrapper value, JsonGenerator gen, Field field) throws IOException {
+		try {
+			Object o = field.get(value);
+			if (o instanceof String) {
+				gen.writeString((String)o);
+			}
+			if (o instanceof Double) {
+				gen.writeNumber((double)o);
+			}
+			if (o instanceof Integer) {
+				gen.writeNumber((int)o);
+			}
+			if (o instanceof Float) {
+				gen.writeNumber((float)o);
+			}
+			if (o instanceof Short) {
+				gen.writeNumber((short)o);
+			}
+			if (o instanceof Long) {
+				gen.writeNumber((long)o);
+			}
+		} catch (IllegalAccessException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+}

--- a/src/test/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfigurationTest.java
+++ b/src/test/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfigurationTest.java
@@ -62,6 +62,16 @@ class JacksonConfigurationTest {
 		assertThat(isISO_LOCAL_DATE_TIME).isTrue();
 	}
 
+	@Test
+	@DisplayName("역직렬화시 입력이 ISO_LOCAL_DATE_TIME인 경우 잘 동작해야 함")
+	void shouldDeserializeWhenInputFormatIsISO_LOCAL_DATE_TIME() throws JsonProcessingException {
+		String jsonString = "{\"date_time\":\"2023-03-02T13:24:27.5431758\"}";
+		DateForTest object = objectMapper.readValue(jsonString, DateForTest.class);
+		assertThat(object)
+			.hasFieldOrPropertyWithValue("dateTime",
+				LocalDateTime.parse("2023-03-02T13:24:27.5431758", DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+	}
+
 	private boolean checkDateTimeFormat(String valueAsString) throws JSONException {
 		JSONObject jsonObject = new JSONObject(valueAsString);
 		String stringDate = jsonObject.getString("date_time");

--- a/src/test/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfigurationTest.java
+++ b/src/test/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfigurationTest.java
@@ -6,6 +6,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -16,10 +18,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.almondia.meca.common.domain.vo.configuration.jackson.module.wrapper.Wrapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,11 +31,15 @@ import lombok.Setter;
 /**
  * 1. 직렬화/역직렬화 수행시 snake_case를 기준으로 동작해야 한다
  * 2. 날짜 데이터도 어노테이션 사용 없이 직렬화/역직렬화가 잘 동작해야 한다
+ * 3. 원시 래핑 클래스의 래핑은 직렬화시 벗겨서 사용해야 한다.
+ * 4. 원시 객체가 역직렬화시 원시 객체 래핑이 되어야 한다.
  */
 @ExtendWith(SpringExtension.class)
 @Import({JacksonConfiguration.class})
 class JacksonConfigurationTest {
 
+	static final Pattern INTEGER = Pattern.compile("^[^0]\\d*$");
+	static final Pattern DOUBLE = Pattern.compile("^[^0]\\d*\\.\\d*[^0]$");
 	@Autowired
 	ObjectMapper objectMapper;
 
@@ -72,6 +80,56 @@ class JacksonConfigurationTest {
 				LocalDateTime.parse("2023-03-02T13:24:27.5431758", DateTimeFormatter.ISO_LOCAL_DATE_TIME));
 	}
 
+	@Test
+	@DisplayName("직렬화시 문자열 원시 객체 래핑 클래스의 경우 innerValue만 리턴")
+	void shouldSerializeInnerStringValueFromSerializePrimitiveWrapperClass() throws JsonProcessingException {
+		Name name = new Name("hello");
+		String s = objectMapper.writeValueAsString(name);
+		assertThat(s).contains("\"");
+	}
+
+	@Test
+	@DisplayName("역직렬화시 String 타입이 String 원시 래핑 객체로 생성되어야 한다")
+	void shouldDeserializeStringToStringWrapperClass() throws JsonProcessingException {
+		String jsonInput = "\"hello\"";
+		Name name = objectMapper.readValue(jsonInput, Name.class);
+		assertThat(name).hasFieldOrPropertyWithValue("name", "hello");
+	}
+
+	@Test
+	@DisplayName("직렬화시 정수형 객체 래핑 클래스의 경우 innerValue만 리턴")
+	void shouldSerializeInnerIntegerValueFromSerializePrimitiveWrapperClass() throws JsonProcessingException {
+		Age age = new Age(10);
+		String s = objectMapper.writeValueAsString(age);
+		Matcher matcher = INTEGER.matcher(s);
+		assertThat(matcher.matches()).isTrue();
+	}
+
+	@Test
+	@DisplayName("역직렬화시 정수 타입이 정수 원시 래핑 객체로 생성되어야 한다")
+	void shouldDeserializeIntegerToIntegerWrapperClass() throws JsonProcessingException {
+		String jsonInput = "10";
+		Age age = objectMapper.readValue(jsonInput, Age.class);
+		assertThat(age).hasFieldOrPropertyWithValue("age", 10);
+	}
+
+	@Test
+	@DisplayName("직렬화시 실수형 객체 래핑 클래스의 경우 innerValue만 리턴")
+	void shouldSerializeInnerDoubleValueFromSerializePrimitiveWrapperClass() throws JsonProcessingException {
+		Meter meter = new Meter(13.76);
+		String s = objectMapper.writeValueAsString(meter);
+		Matcher matcher = DOUBLE.matcher(s);
+		assertThat(matcher.matches()).isTrue();
+	}
+
+	@Test
+	@DisplayName("역직렬화시 실수 타입이 정수 원시 래핑 객체로 생성되어야 한다")
+	void shouldDeserializeDoubleToDoubleWrapperClass() throws JsonProcessingException {
+		String jsonInput = "10.37";
+		Meter meter = objectMapper.readValue(jsonInput, Meter.class);
+		assertThat(meter).hasFieldOrPropertyWithValue("meter", 10.37);
+	}
+
 	private boolean checkDateTimeFormat(String valueAsString) throws JSONException {
 		JSONObject jsonObject = new JSONObject(valueAsString);
 		String stringDate = jsonObject.getString("date_time");
@@ -98,5 +156,32 @@ class JacksonConfigurationTest {
 	static class Dto {
 		private String userName;
 		private int userAge;
+	}
+
+	@EqualsAndHashCode
+	static class Age implements Wrapper {
+		private final int age;
+
+		public Age(int age) {
+			this.age = age;
+		}
+	}
+
+	@EqualsAndHashCode
+	static class Meter implements Wrapper {
+		private final double meter;
+
+		public Meter(double meter) {
+			this.meter = meter;
+		}
+	}
+
+	@EqualsAndHashCode
+	static class Name implements Wrapper {
+		private final String name;
+
+		public Name(String name) {
+			this.name = name;
+		}
 	}
 }

--- a/src/test/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfigurationTest.java
+++ b/src/test/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfigurationTest.java
@@ -2,6 +2,13 @@ package com.almondia.meca.common.domain.vo.configuration.jackson;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +26,7 @@ import lombok.Setter;
 
 /**
  * 1. 직렬화/역직렬화 수행시 snake_case를 기준으로 동작해야 한다
+ * 2. 날짜 데이터도 어노테이션 사용 없이 직렬화/역직렬화가 잘 동작해야 한다
  */
 @ExtendWith(SpringExtension.class)
 @Import({JacksonConfiguration.class})
@@ -43,6 +51,34 @@ class JacksonConfigurationTest {
 		assertThat(dto)
 			.hasFieldOrPropertyWithValue("userName", "hello")
 			.hasFieldOrPropertyWithValue("userAge", 10);
+	}
+
+	@Test
+	@DisplayName("직렬화시 LocalDateTime이 어노테이션 없이 잘 동작해야 함")
+	void shouldSerializeWithoutJacksonAnnotation() throws JsonProcessingException, JSONException {
+		DateForTest dateForTest = new DateForTest(LocalDateTime.now());
+		String valueAsString = objectMapper.writeValueAsString(dateForTest);
+		boolean isISO_LOCAL_DATE_TIME = checkDateTimeFormat(valueAsString);
+		assertThat(isISO_LOCAL_DATE_TIME).isTrue();
+	}
+
+	private boolean checkDateTimeFormat(String valueAsString) throws JSONException {
+		JSONObject jsonObject = new JSONObject(valueAsString);
+		String stringDate = jsonObject.getString("date_time");
+		try {
+			LocalDate date = LocalDate.parse(stringDate, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+			return true;
+		} catch (DateTimeParseException e) {
+			return false;
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Setter
+	static class DateForTest {
+		private LocalDateTime dateTime;
 	}
 
 	@Getter

--- a/src/test/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfigurationTest.java
+++ b/src/test/java/com/almondia/meca/common/domain/vo/configuration/jackson/JacksonConfigurationTest.java
@@ -1,0 +1,56 @@
+package com.almondia.meca.common.domain.vo.configuration.jackson;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 1. 직렬화/역직렬화 수행시 snake_case를 기준으로 동작해야 한다
+ */
+@ExtendWith(SpringExtension.class)
+@Import({JacksonConfiguration.class})
+class JacksonConfigurationTest {
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("직렬화시 snake case형태의 json string으로 변환해야 함")
+	void shouldReturnSnakeCaseKeyNameWhenSerializeUsingObjectMapper() throws JsonProcessingException {
+		Dto dto = new Dto("hello", 10);
+		String value = objectMapper.writeValueAsString(dto);
+		assertThat(value).contains("user_name", "user_age");
+	}
+
+	@Test
+	@DisplayName("역직렬화시 snake case형태의 json string을 객체로 변환할 수 있어야 함")
+	void shouldReturnClassWhenDeSerializeSnakeCaseKeyJsonStringUsingObjectMapper() throws JsonProcessingException {
+		String input = "{\"user_name\":\"hello\",\"user_age\":10}";
+		Dto dto = objectMapper.readValue(input, Dto.class);
+		assertThat(dto)
+			.hasFieldOrPropertyWithValue("userName", "hello")
+			.hasFieldOrPropertyWithValue("userAge", 10);
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Setter
+	static class Dto {
+		private String userName;
+		private int userAge;
+	}
+}


### PR DESCRIPTION
## 요약
- LocalDateTime 입출력 형식이 ISO_LOCAL_DATE_TIME이다
    - 입/출력 예시: 2011-12-03T10:15:30'
- Wrapper 클래스의 경우 Wrapper interface 타입을 선언하면 리플렉션을 활용해서 래핑 객체를 벗겨내서 내부 변수로 직렬화 수행
- Wrapper 타입의 클래스는 역직렬화시 원시 타입 객체를 자동으로 래핑하도록 함