### PR TITLE
feat/#5: 회원 도메인 기능 추가

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -9,8 +9,6 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: 1234
       MYSQL_DATABASE: test-db
-      MYSQL_USER: root
-      MYSQL_PASSWORD: 1234
 
     command:
       - --character-set-server=utf8mb4

--- a/src/main/java/com/almondia/meca/common/configuration/jackson/module/wrapper/WrapperSerializer.java
+++ b/src/main/java/com/almondia/meca/common/configuration/jackson/module/wrapper/WrapperSerializer.java
@@ -2,6 +2,9 @@ package com.almondia.meca.common.configuration.jackson.module.wrapper;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.UUID;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -18,16 +21,21 @@ public class WrapperSerializer extends StdSerializer<Wrapper> {
 	}
 
 	@Override
-	public void serialize(Wrapper value, JsonGenerator gen, SerializerProvider provider)
-		throws IOException {
+	public void serialize(Wrapper value, JsonGenerator gen, SerializerProvider provider) throws IOException {
 		Class<?> clazz = value.getClass();
-		Field[] fields = clazz.getDeclaredFields();
+		Field[] fields = Stream.of(clazz.getDeclaredFields()).filter(this::isPurePropertyField).toArray(Field[]::new);
 		if (fields.length != 1) {
-			throw new IllegalStateException();
+			throw new IllegalStateException("It has not one property" + "property numbers: " + fields.length);
 		}
 		Field field = fields[0];
 		field.setAccessible(true);
 		makeJsonByFieldType(value, gen, field);
+	}
+
+	private boolean isPurePropertyField(Field field) {
+		int modifiers = field.getModifiers();
+		return !Modifier.isTransient(modifiers) && !Modifier.isNative(modifiers) && !Modifier.isVolatile(modifiers)
+			&& !Modifier.isStatic(modifiers);
 	}
 
 	private void makeJsonByFieldType(Wrapper value, JsonGenerator gen, Field field) throws IOException {
@@ -35,6 +43,9 @@ public class WrapperSerializer extends StdSerializer<Wrapper> {
 			Object o = field.get(value);
 			if (o instanceof String) {
 				gen.writeString((String)o);
+			}
+			if (o instanceof UUID) {
+				gen.writeString(o.toString());
 			}
 			if (o instanceof Double) {
 				gen.writeNumber((double)o);

--- a/src/main/java/com/almondia/meca/common/configuration/jpa/JpaAuditingConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/configuration/jpa/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.almondia.meca.common.configuration.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/com/almondia/meca/common/domain/entity/DateEntity.java
+++ b/src/main/java/com/almondia/meca/common/domain/entity/DateEntity.java
@@ -1,0 +1,29 @@
+package com.almondia.meca.common.domain.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public abstract class DateEntity {
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/almondia/meca/common/domain/vo/Id.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/Id.java
@@ -1,0 +1,40 @@
+package com.almondia.meca.common.domain.vo;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import javax.persistence.Embeddable;
+
+import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Id implements Serializable, Wrapper {
+
+	private static final long serialVersionUID = -2772995063676474658L;
+
+	private UUID uuid;
+
+	public Id(UUID uuid) {
+		this.uuid = uuid;
+	}
+
+	public Id(String uuid) {
+		this.uuid = UUID.fromString(uuid);
+	}
+
+	public static Id generateNextId() {
+		UUID uuid = UUID.randomUUID();
+		return new Id(uuid);
+	}
+
+	@Override
+	public String toString() {
+		return uuid.toString();
+	}
+}

--- a/src/main/java/com/almondia/meca/member/domain/entity/Member.java
+++ b/src/main/java/com/almondia/meca/member/domain/entity/Member.java
@@ -1,0 +1,61 @@
+package com.almondia.meca.member.domain.entity;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+import com.almondia.meca.common.domain.entity.DateEntity;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.vo.Email;
+import com.almondia.meca.member.domain.vo.Name;
+import com.almondia.meca.member.domain.vo.OAuthType;
+import com.almondia.meca.member.domain.vo.Role;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@SuperBuilder
+public class Member extends DateEntity {
+
+	@EmbeddedId
+	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, columnDefinition = "BINARY(16)"))
+	private Id memberId;
+
+	@Embedded
+	@AttributeOverride(name = "name", column = @Column(name = "name", nullable = false, columnDefinition = "VARCHAR(40)"))
+	private Name name;
+
+	@Embedded
+	@AttributeOverride(name = "email", column = @Column(name = "email", nullable = false, columnDefinition = "VARCHAR(255)"))
+	private Email email;
+
+	@Column(name = "o_auth_type", nullable = false, columnDefinition = "VARCHAR(10)")
+	private OAuthType oAuthType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "role", nullable = false, columnDefinition = "VARCHAR(10)")
+	private Role role;
+
+	private boolean isDeleted;
+
+	public void delete() {
+		this.isDeleted = true;
+	}
+
+	public void restore() {
+		this.isDeleted = false;
+	}
+
+	public boolean isDeleted() {
+		return this.isDeleted;
+	}
+}

--- a/src/main/java/com/almondia/meca/member/domain/vo/Email.java
+++ b/src/main/java/com/almondia/meca/member/domain/vo/Email.java
@@ -1,0 +1,38 @@
+package com.almondia.meca.member.domain.vo;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.persistence.Embeddable;
+
+import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Email implements Wrapper {
+
+	private static final Pattern EMAIL_PATTERN = Pattern.compile("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$");
+	private String email;
+
+	public Email(String email) {
+		validateEmailFormat(email);
+		this.email = email;
+	}
+
+	private void validateEmailFormat(String email) {
+		Matcher matcher = EMAIL_PATTERN.matcher(email);
+		if (!matcher.matches()) {
+			throw new IllegalArgumentException("이메일 형식과 일치하지 않습니다");
+		}
+	}
+
+	@Override
+	public String toString() {
+		return email;
+	}
+}

--- a/src/main/java/com/almondia/meca/member/domain/vo/Name.java
+++ b/src/main/java/com/almondia/meca/member/domain/vo/Name.java
@@ -1,0 +1,38 @@
+package com.almondia.meca.member.domain.vo;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.persistence.Embeddable;
+
+import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Name implements Wrapper {
+
+	private static final Pattern NAME_PATTERN = Pattern.compile("^[a-zA-Z가-힣]{1,20}$");
+	private String name;
+
+	public Name(String name) {
+		validateNameFormat(name);
+		this.name = name;
+	}
+
+	private void validateNameFormat(String name) {
+		Matcher matcher = NAME_PATTERN.matcher(name);
+		if (!matcher.find()) {
+			throw new IllegalArgumentException("이름은 영문 또는 한글 1 ~ 20 사이만 입력 가능합니다");
+		}
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+}

--- a/src/main/java/com/almondia/meca/member/domain/vo/OAuthType.java
+++ b/src/main/java/com/almondia/meca/member/domain/vo/OAuthType.java
@@ -1,0 +1,25 @@
+package com.almondia.meca.member.domain.vo;
+
+import java.util.stream.Stream;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OAuthType {
+
+	KAKAO("kakao"),
+	NAVER("naver"),
+	GOOGLE("google");
+
+	private static final String ERROR_MESSAGE = "잘못된 입력입니다. kakao, naver, google 셋 중 하나 입력해주세요";
+	private final String details;
+
+	public static OAuthType fromOAuthType(String value) {
+		return Stream.of(OAuthType.values())
+			.filter(oAuthType -> value.equals(oAuthType.details))
+			.findAny()
+			.orElseThrow(() -> new IllegalArgumentException(ERROR_MESSAGE));
+	}
+}

--- a/src/main/java/com/almondia/meca/member/domain/vo/Role.java
+++ b/src/main/java/com/almondia/meca/member/domain/vo/Role.java
@@ -1,0 +1,20 @@
+package com.almondia.meca.member.domain.vo;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+	ADMIN("ROLE_ADMIN"),
+	USER("ROLE_USER"),
+	NONE("NONE");
+
+	private final String details;
+
+	Role(String details) {
+		this.details = details;
+	}
+
+	public boolean hasRole() {
+		return !this.equals(NONE);
+	}
+}

--- a/src/main/java/com/almondia/meca/member/domain/vo/converter/OAuthTypeConverter.java
+++ b/src/main/java/com/almondia/meca/member/domain/vo/converter/OAuthTypeConverter.java
@@ -1,0 +1,20 @@
+package com.almondia.meca.member.domain.vo.converter;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import com.almondia.meca.member.domain.vo.OAuthType;
+
+@Converter(autoApply = true)
+public class OAuthTypeConverter implements AttributeConverter<OAuthType, String> {
+
+	@Override
+	public String convertToDatabaseColumn(OAuthType attribute) {
+		return attribute == null ? null : attribute.getDetails();
+	}
+
+	@Override
+	public OAuthType convertToEntityAttribute(String dbData) {
+		return dbData == null ? null : OAuthType.fromOAuthType(dbData);
+	}
+}

--- a/src/test/java/com/almondia/meca/common/domain/entity/DateEntityTest.java
+++ b/src/test/java/com/almondia/meca/common/domain/entity/DateEntityTest.java
@@ -1,0 +1,78 @@
+package com.almondia.meca.common.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
+import org.springframework.test.context.TestPropertySource;
+
+import com.almondia.meca.common.configuration.jpa.JpaAuditingConfiguration;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * 1. 생성시 자동으로 날짜가 자동으로 생성되어야 함(생성일 == 수정일).
+ * 2. 업데이트시 업데이트 날짜가 자동으로 업데이트 되어야 함(생성일 < 수정일).
+ */
+@DataJpaTest
+@TestPropertySource(properties = {
+	"spring.jpa.hibernate.ddl-auto=create-drop"
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfiguration.class})
+class DateEntityTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("영속시 생성일 날짜가 업데이트 됨 생성, 수정일 날짜가 같아야 한다.")
+	void shouldUpdateCreatedAtPropertyWhenPersist() {
+		Temp temp = new Temp(Id.generateNextId(), false);
+		entityManager.persist(temp);
+		assertThat(temp.getCreatedAt()).isNotNull();
+		assertThat(temp.getModifiedAt()).isNotNull();
+		assertThat(temp.getCreatedAt()).isEqualTo(temp.getModifiedAt());
+	}
+
+	@Test
+	@DisplayName("영속화된 데이터를 꺼내서 수정하면 modifiedAt이 업데이트 수정 날짜가 생성 날짜보다 이 후여야 한다.")
+	void test() throws InterruptedException {
+		Temp temp = new Temp(Id.generateNextId(), false);
+		JpaRepository<Temp, Id> tempRepository = new SimpleJpaRepository<>(Temp.class, entityManager);
+		tempRepository.save(temp);
+		Thread.sleep(200);
+		Temp entity = tempRepository.findById(temp.getId()).orElseThrow();
+
+		assertThat(entity.getModifiedAt()).isAfterOrEqualTo(entity.getCreatedAt());
+	}
+
+	@Entity
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor
+	@Getter
+	@Setter
+	@ToString
+	static class Temp extends DateEntity {
+		@EmbeddedId
+		private Id id;
+
+		private boolean isActivate;
+	}
+}

--- a/src/test/java/com/almondia/meca/common/domain/vo/IdTest.java
+++ b/src/test/java/com/almondia/meca/common/domain/vo/IdTest.java
@@ -1,0 +1,43 @@
+package com.almondia.meca.common.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * 직렬화/역직렬화 테스트
+ */
+@ExtendWith(SpringExtension.class)
+@Import({JacksonConfiguration.class})
+class IdTest {
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("id 직렬화 테스트")
+	void serializeTest() throws JsonProcessingException {
+		Id id = Id.generateNextId();
+		String value = objectMapper.writeValueAsString(id);
+		System.out.println(value);
+		assertThat(value).isEqualTo("\"" + id + "\"");
+	}
+
+	@Test
+	@DisplayName("id 역직렬화 테스트")
+	void deSerializeTest() throws JsonProcessingException {
+		Id id = Id.generateNextId();
+		String jsonInput = "\"" + id + "\"";
+		Id result = objectMapper.readValue(jsonInput, Id.class);
+		assertThat(result).isEqualTo(id);
+	}
+}

--- a/src/test/java/com/almondia/meca/member/domain/entity/MemberTest.java
+++ b/src/test/java/com/almondia/meca/member/domain/entity/MemberTest.java
@@ -1,0 +1,90 @@
+package com.almondia.meca.member.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.metamodel.EntityType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
+import org.springframework.test.context.TestPropertySource;
+
+import com.almondia.meca.common.configuration.jpa.JpaAuditingConfiguration;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.vo.Email;
+import com.almondia.meca.member.domain.vo.Name;
+import com.almondia.meca.member.domain.vo.OAuthType;
+import com.almondia.meca.member.domain.vo.Role;
+
+/**
+ * 1. meta데이터를 통해 entity 속성이 잘 생성되었는지 테스트
+ * 2. 영속화시 Member에 날짜가 자동으로 갱신되는지 테스트
+ */
+@DataJpaTest
+@TestPropertySource(properties = {"spring.jpa.hibernate.ddl-auto=create-drop"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfiguration.class})
+class MemberTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("유저 속성이 잘 생성되었는지 검증")
+	void memberEntityCreationTest() {
+		EntityType<?> entityType = entityManager.getMetamodel().entity(Member.class);
+		assertThat(entityType).isNotNull();
+		assertThat(entityType.getName()).isEqualTo("Member");
+		assertThat(entityType.getAttributes()).extracting("name")
+			.containsExactlyInAnyOrder("memberId", "name", "email", "oAuthType", "createdAt", "modifiedAt",
+				"role", "isDeleted");
+	}
+
+	@Test
+	@DisplayName("entity를 생성해서 저장시 createdAt과 modifiedAt이 자동으로 업데이트되며 서로 같음")
+	void shouldUpdateCreatedAtAndModifiedAtAndTheyAreEqualWhenEntitySave() {
+		JpaRepository<Member, Id> memberRepository = new SimpleJpaRepository<>(Member.class, entityManager);
+		Member member = Member.builder()
+			.memberId(Id.generateNextId())
+			.email(new Email("hello@naver.com"))
+			.name(new Name("hello"))
+			.oAuthType(OAuthType.GOOGLE)
+			.role(Role.USER)
+			.isDeleted(false)
+			.build();
+		memberRepository.save(member);
+		Member result = memberRepository.findById(member.getMemberId()).orElseThrow();
+		LocalDateTime createdAt = result.getCreatedAt();
+		LocalDateTime modifiedAt = result.getModifiedAt();
+		assertThat(createdAt).isEqualTo(modifiedAt);
+	}
+
+	@Test
+	@DisplayName("entity 수정시 modifiedAt이 업데이트되며 modifiedAt이 createdAt보다 이후의 날짜여야 함")
+	void shouldUpdateModifiedAtAndModifiedAtAfterThanCreatedAtWhenEntityUpdate() throws InterruptedException {
+		JpaRepository<Member, Id> memberRepository = new SimpleJpaRepository<>(Member.class, entityManager);
+		Member member = Member.builder()
+			.memberId(Id.generateNextId())
+			.email(new Email("hello@naver.com"))
+			.name(new Name("hello"))
+			.oAuthType(OAuthType.GOOGLE)
+			.role(Role.USER)
+			.isDeleted(false)
+			.build();
+		memberRepository.save(member);
+		Member temp = memberRepository.findById(member.getMemberId()).orElseThrow();
+		temp.delete();
+		memberRepository.saveAndFlush(temp);
+		Thread.sleep(100);
+		Member result = memberRepository.findById(member.getMemberId()).orElseThrow();
+		assertThat(result.getModifiedAt()).isAfter(result.getCreatedAt());
+	}
+}

--- a/src/test/java/com/almondia/meca/member/domain/vo/EmailTest.java
+++ b/src/test/java/com/almondia/meca/member/domain/vo/EmailTest.java
@@ -1,0 +1,31 @@
+package com.almondia.meca.member.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * 1. toString 시 내부 객체의 정보를 보여준다.
+ * 2. email 형식의 문자열만 허용한다.
+ */
+class EmailTest {
+
+	@Test
+	@DisplayName("toString과 내부 객체 정보 일치")
+	void shouldReturnIntervalValueWhenToString() {
+		Email email = new Email("hello@naver.com");
+		assertThat(email.toString()).isEqualTo("hello@naver.com");
+	}
+
+	@ParameterizedTest
+	@DisplayName("Email format 검증")
+	@CsvSource({
+		"hello@@naver.com", "h3@", "hello.com",
+	})
+	void shouldThrowIllegalArgumentExceptionWhenInvalidInput(String input) {
+		assertThatThrownBy(() -> new Email(input)).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/com/almondia/meca/member/domain/vo/NameTest.java
+++ b/src/test/java/com/almondia/meca/member/domain/vo/NameTest.java
@@ -1,0 +1,30 @@
+package com.almondia.meca.member.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * 1. toString 시 내부 객체의 정보를 보여준다.
+ * 2. 영문자, 또는 한글 1 ~ 20까지 허용한다.
+ */
+class NameTest {
+
+	@Test
+	@DisplayName("toString과 내부 객체 정보 일치")
+	void shouldReturnIntervalValueWhenToString() {
+		Name name = new Name("최번개");
+		assertThat(name.toString()).isEqualTo("최번개");
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+		"as1", "12", "aaasdfaasdsdsdsdsdsdaa", "가1",
+	})
+	void shouldThrowIllegalArgumentExceptionWhenInvalidInput(String input) {
+		assertThatThrownBy(() -> new Name(input)).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/com/almondia/meca/member/domain/vo/OAuthTypeTest.java
+++ b/src/test/java/com/almondia/meca/member/domain/vo/OAuthTypeTest.java
@@ -1,0 +1,55 @@
+package com.almondia.meca.member.domain.vo;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+/**
+ * OAuthType은 kakao, google, naver 문자열 입력만 변환 가능
+ */
+@DataJpaTest
+@TestPropertySource(properties = {"spring.jpa.hibernate.ddl-auto=create-drop"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class OAuthTypeTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@ParameterizedTest
+	@DisplayName("OAuthType에 정의된 인스턴스 멤버 변수만 타입으로 변환 가능")
+	@CsvSource({"kakaos", "google3", "navera"})
+	void shouldReturnOAuthTypeFromString(String registrationId) {
+		assertThatThrownBy(() -> OAuthType.fromOAuthType(registrationId)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void converterTest() {
+		TempEntity tempEntity = new TempEntity(Id.generateNextId(), OAuthType.GOOGLE);
+		entityManager.persist(tempEntity);
+	}
+
+	@Entity
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class TempEntity {
+
+		@javax.persistence.Id
+		private Id id;
+		private OAuthType oauthType;
+	}
+}

--- a/src/test/java/com/almondia/meca/member/domain/vo/RoleTest.java
+++ b/src/test/java/com/almondia/meca/member/domain/vo/RoleTest.java
@@ -1,0 +1,19 @@
+package com.almondia.meca.member.domain.vo;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * hasRole 동작 검증
+ */
+class RoleTest {
+
+	@Test
+	@DisplayName("Role이 None인 경우 hasRole()은 False를 리턴한다")
+	void shouldReturnFalseIfRoleIsNotNone() {
+		Role role = Role.NONE;
+		assertThat(role.hasRole()).isFalse();
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/test-db?characterEncoding=UTF-8&serverTimezone=Asia/Seoul&useSSL=false
+    url: jdbc:mysql://localhost:3306/test-db?characterEncoding=UTF-8&serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
     username: root
     password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 요약

- 회원 엔티티 속성(member_id, role, createdAt, modifiedAt, name, email, oAuthType, isDeleted)
- 회원 엔티티 Member는 delete 관련 속성 메서드 기능 추가
- db 설정에서 root 계정 충돌 문제 해결
- 테스트에서 Jackson Module이 UUID를 인식 못하는 점과 엉뚱한 인스턴스 변수를 인식하는 문제 개선
