### PR TITLE
feat/#2: OAuth2 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok:'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    // webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok:'
     testAnnotationProcessor 'org.projectlombok:lombok'
+    
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.3'
 
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // mock web server
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // json object
+    implementation 'org.json:json:20211205'
+
     // db
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     // mock web server
     testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
 
+    // reactor test
+    testImplementation 'io.projectreactor:reactor-test'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/com/almondia/meca/auth/dto/AccessTokenResponseDto.java
+++ b/src/main/java/com/almondia/meca/auth/dto/AccessTokenResponseDto.java
@@ -1,0 +1,16 @@
+package com.almondia.meca.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class AccessTokenResponseDto {
+	private final String accessToken;
+
+	public static AccessTokenResponseDto of(String accessToken) {
+		return new AccessTokenResponseDto(accessToken);
+	}
+}

--- a/src/main/java/com/almondia/meca/auth/jwt/service/JwtTokenService.java
+++ b/src/main/java/com/almondia/meca/auth/jwt/service/JwtTokenService.java
@@ -1,0 +1,67 @@
+package com.almondia.meca.auth.jwt.service;
+
+import java.security.Key;
+import java.time.Instant;
+import java.util.Date;
+
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Service;
+
+import com.almondia.meca.common.configuration.jwt.JwtProperties;
+import com.almondia.meca.common.domain.vo.Id;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+	private static final String ID_CLAIM_KEY = "id";
+	private final JwtProperties jwtProperties;
+
+	public String createToken(Id id) {
+		Instant now = Instant.now();
+		Instant expirationDate = now.plusMillis(jwtProperties.getExpirationMs());
+		Claims claims = Jwts.claims();
+		claims.put(ID_CLAIM_KEY, id.toString());
+		return Jwts.builder()
+			.setSubject(id.toString())
+			.setIssuedAt(Date.from(now))
+			.setClaims(claims)
+			.setExpiration(Date.from(expirationDate))
+			.signWith(getSigningKey(), SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	public String getIdFromToken(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(getSigningKey())
+			.build()
+			.parseClaimsJws(token)
+			.getBody()
+			.get(ID_CLAIM_KEY, String.class);
+	}
+
+	public boolean isValidToken(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token);
+			return true;
+		} catch (JwtException | IllegalArgumentException | MalformedJwtException e) {
+			return false;
+		}
+	}
+
+	private byte[] getSecretKeyBytes() {
+		return Decoders.BASE64.decode(jwtProperties.getSecretKey());
+	}
+
+	private Key getSigningKey() {
+		return Keys.hmacShaKeyFor(getSecretKeyBytes());
+	}
+}

--- a/src/main/java/com/almondia/meca/auth/oauth/exception/BadWebClientRequestException.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/exception/BadWebClientRequestException.java
@@ -1,0 +1,8 @@
+package com.almondia.meca.auth.oauth.exception;
+
+public class BadWebClientRequestException extends RuntimeException {
+
+	public BadWebClientRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/almondia/meca/auth/oauth/exception/BadWebClientResponseException.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/exception/BadWebClientResponseException.java
@@ -1,0 +1,8 @@
+package com.almondia.meca.auth.oauth.exception;
+
+public class BadWebClientResponseException extends RuntimeException {
+
+	public BadWebClientResponseException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/almondia/meca/auth/oauth/infra/CustomOAuth2Client.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/infra/CustomOAuth2Client.java
@@ -2,7 +2,10 @@ package com.almondia.meca.auth.oauth.infra;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.stereotype.Component;
@@ -33,6 +36,18 @@ public class CustomOAuth2Client {
 			.bodyToMono(OAuth2AccessTokenResponse.class);
 	}
 
+	public Mono<Map<String, Object>> requestUserInfo(String registrationId,
+		OAuth2AccessTokenResponse oauth2AccessToken) {
+		ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(
+			registrationId);
+		return webClient.get()
+			.uri(requestUserInfoUri(registration))
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + oauth2AccessToken.getAccessToken())
+			.retrieve()
+			.bodyToMono(new ParameterizedTypeReference<>() {
+			});
+	}
+
 	private URI requestAccessTokenUri(ClientRegistration registration,
 		String authorizationCode) {
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -45,6 +60,14 @@ public class CustomOAuth2Client {
 		return UriComponentsBuilder
 			.fromUriString(registration.getProviderDetails().getTokenUri())
 			.queryParams(params)
+			.build()
+			.encode(StandardCharsets.UTF_8)
+			.toUri();
+	}
+
+	private URI requestUserInfoUri(ClientRegistration registration) {
+		return UriComponentsBuilder
+			.fromUriString(registration.getProviderDetails().getUserInfoEndpoint().getUri())
 			.build()
 			.encode(StandardCharsets.UTF_8)
 			.toUri();

--- a/src/main/java/com/almondia/meca/auth/oauth/infra/CustomOAuth2Client.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/infra/CustomOAuth2Client.java
@@ -1,0 +1,52 @@
+package com.almondia.meca.auth.oauth.infra;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.almondia.meca.auth.oauth.infra.dto.OAuth2AccessTokenResponse;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2Client {
+
+	private final ClientRegistrationRepository clientRegistrationRepository;
+	private final WebClient webClient;
+
+	public Mono<OAuth2AccessTokenResponse> requestAccessToken(String registrationId,
+		String authorizationCode) {
+		ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(
+			registrationId);
+		return webClient.post()
+			.uri(requestAccessTokenUri(registration, authorizationCode))
+			.retrieve()
+			.bodyToMono(OAuth2AccessTokenResponse.class);
+	}
+
+	private URI requestAccessTokenUri(ClientRegistration registration,
+		String authorizationCode) {
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("grant_type", "authorization_code");
+		params.add("client_id", registration.getClientId());
+		params.add("redirect_uri", registration.getRedirectUri());
+		params.add("code", authorizationCode);
+		params.add("client_secret", registration.getClientSecret());
+
+		return UriComponentsBuilder
+			.fromUriString(registration.getProviderDetails().getTokenUri())
+			.queryParams(params)
+			.build()
+			.encode(StandardCharsets.UTF_8)
+			.toUri();
+	}
+}

--- a/src/main/java/com/almondia/meca/auth/oauth/infra/attribute/OAuth2UserAttribute.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/infra/attribute/OAuth2UserAttribute.java
@@ -1,0 +1,21 @@
+package com.almondia.meca.auth.oauth.infra.attribute;
+
+import com.almondia.meca.member.domain.vo.OAuthType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class OAuth2UserAttribute {
+
+	private final String name;
+	private final String email;
+	private final OAuthType oauthType;
+
+	public static OAuth2UserAttribute of(String name, String email, OAuthType oauthType) {
+		return new OAuth2UserAttribute(name, email, oauthType);
+	}
+}

--- a/src/main/java/com/almondia/meca/auth/oauth/infra/dto/OAuth2AccessTokenResponse.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/infra/dto/OAuth2AccessTokenResponse.java
@@ -1,0 +1,31 @@
+package com.almondia.meca.auth.oauth.infra.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public final class OAuth2AccessTokenResponse {
+
+	@JsonProperty("access_token")
+	private String accessToken;
+	@JsonProperty("token_type")
+	private String tokenType;
+	@JsonProperty("refresh_token")
+	private String refreshToken;
+	@JsonProperty("expires_in")
+	private Long expiresIn;
+	@JsonProperty("scope")
+	private String scope;
+}
+

--- a/src/main/java/com/almondia/meca/auth/oauth/service/Oauth2Service.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/service/Oauth2Service.java
@@ -1,0 +1,29 @@
+package com.almondia.meca.auth.oauth.service;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+
+import com.almondia.meca.auth.oauth.infra.CustomOAuth2Client;
+import com.almondia.meca.auth.oauth.infra.attribute.OAuth2UserAttribute;
+import com.almondia.meca.auth.oauth.infra.dto.OAuth2AccessTokenResponse;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class Oauth2Service {
+
+	private final CustomOAuth2Client oAuth2Client;
+
+	public OAuth2UserAttribute requestUserInfo(String registrationId, String authorizationCode) {
+		Mono<OAuth2AccessTokenResponse> response = oAuth2Client.requestAccessToken(registrationId, authorizationCode);
+		OAuth2AccessTokenResponse tokenResponse = response.block();
+		Mono<Map<String, Object>> monoUserInfo = oAuth2Client.requestUserInfo(registrationId,
+			Objects.requireNonNull(tokenResponse));
+		UserInfoExtractor extractor = UserInfoExtractor.getInstance(registrationId);
+		return extractor.extract(monoUserInfo.block());
+	}
+}

--- a/src/main/java/com/almondia/meca/auth/oauth/service/UserInfoExtractor.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/service/UserInfoExtractor.java
@@ -1,0 +1,59 @@
+package com.almondia.meca.auth.oauth.service;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.json.JSONObject;
+
+import com.almondia.meca.auth.oauth.infra.attribute.OAuth2UserAttribute;
+import com.almondia.meca.member.domain.vo.OAuthType;
+
+public enum UserInfoExtractor {
+	NAVER("naver") {
+		@Override
+		public OAuth2UserAttribute extract(Map<String, Object> userInfoJson) {
+			JSONObject userInfo = new JSONObject(userInfoJson);
+			JSONObject response = userInfo.getJSONObject("response");
+			String name = response.getString("name");
+			String email = response.getString("email");
+			return OAuth2UserAttribute.of(name, email, OAuthType.NAVER);
+		}
+	},
+	KAKAO("kakao") {
+		@Override
+		public OAuth2UserAttribute extract(Map<String, Object> userInfoJson) {
+			JSONObject userInfo = new JSONObject(userInfoJson);
+			JSONObject properties = userInfo.getJSONObject("properties");
+			JSONObject kakaoAccount = userInfo.getJSONObject("kakao_account");
+			String name = properties.getString("nickname");
+			String email = kakaoAccount.getString("email");
+			return OAuth2UserAttribute.of(name, email, OAuthType.KAKAO);
+		}
+	},
+	GOOGLE("google") {
+		@Override
+		public OAuth2UserAttribute extract(Map<String, Object> userInfoJson) {
+			JSONObject userInfo = new JSONObject(userInfoJson);
+			String email = userInfo.getString("email");
+			String name = userInfo.getString("name");
+			return OAuth2UserAttribute.of(name, email, OAuthType.GOOGLE);
+		}
+	};
+
+	private static final String NOT_FOUND_INSTANCE_MESSAGE = "not found client name";
+
+	private final String clientName;
+
+	UserInfoExtractor(String clientName) {
+		this.clientName = clientName;
+	}
+
+	public static UserInfoExtractor getInstance(String clientName) {
+		return Arrays.stream(UserInfoExtractor.values())
+			.filter(userInfoExtractor -> clientName.equals(userInfoExtractor.clientName))
+			.findAny()
+			.orElseThrow(() -> new IllegalArgumentException(NOT_FOUND_INSTANCE_MESSAGE));
+	}
+
+	public abstract OAuth2UserAttribute extract(Map<String, Object> userInfoJson);
+}

--- a/src/main/java/com/almondia/meca/common/configuration/AppConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/configuration/AppConfiguration.java
@@ -1,0 +1,34 @@
+package com.almondia.meca.common.configuration;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import reactor.netty.http.client.HttpClient;
+
+@Configuration
+public class AppConfiguration {
+
+	@Bean
+	public WebClient getWebClient() {
+		return WebClient.builder()
+			.clientConnector(new ReactorClientHttpConnector(getHttpClient()))
+			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+			.build();
+	}
+
+	private HttpClient getHttpClient() {
+		return HttpClient.create()
+			.responseTimeout(Duration.ofSeconds(5))
+			.doOnConnected(connection -> connection.addHandlerLast(new ReadTimeoutHandler(5))
+				.addHandlerLast(new WriteTimeoutHandler(5)));
+	}
+
+}

--- a/src/main/java/com/almondia/meca/common/configuration/AppConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/configuration/AppConfiguration.java
@@ -21,6 +21,7 @@ public class AppConfiguration {
 		return WebClient.builder()
 			.clientConnector(new ReactorClientHttpConnector(getHttpClient()))
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+			.filter(new WebClientExceptionHandler())
 			.build();
 	}
 

--- a/src/main/java/com/almondia/meca/common/configuration/WebClientExceptionHandler.java
+++ b/src/main/java/com/almondia/meca/common/configuration/WebClientExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.almondia.meca.common.configuration;
+
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+
+import com.almondia.meca.auth.oauth.exception.BadWebClientRequestException;
+import com.almondia.meca.auth.oauth.exception.BadWebClientResponseException;
+
+import reactor.core.publisher.Mono;
+
+public class WebClientExceptionHandler implements ExchangeFilterFunction {
+
+	private static final String BAD_WEB_REQUEST_FORMAT = "4xx 외부 API 요청 오류, status code : %d, response: %s, header: %s";
+	private static final String BAD_WEB_RESPONSE_FORMAT = "5xx 외부 API 요청 오류, status code : %d, response: %s, header: %s";
+
+	@Override
+	public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
+		return next.exchange(request)
+			.flatMap(response -> {
+				if (response.statusCode().is4xxClientError()) {
+					return Mono.error(new BadWebClientRequestException(
+						String.format(BAD_WEB_REQUEST_FORMAT,
+							response.rawStatusCode(),
+							response.bodyToMono(String.class),
+							response.headers().asHttpHeaders()
+						)));
+				}
+				if (response.statusCode().is5xxServerError()) {
+					return Mono.error(new BadWebClientResponseException(String.format(BAD_WEB_RESPONSE_FORMAT,
+						response.rawStatusCode(),
+						response.bodyToMono(String.class),
+						response.headers().asHttpHeaders()
+					)));
+				}
+				return Mono.just(response);
+			});
+	}
+}

--- a/src/main/java/com/almondia/meca/common/configuration/jwt/JwtProperties.java
+++ b/src/main/java/com/almondia/meca/common/configuration/jwt/JwtProperties.java
@@ -1,0 +1,20 @@
+package com.almondia.meca.common.configuration.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+@NoArgsConstructor
+@Setter
+@Getter
+public class JwtProperties {
+
+	private String secretKey;
+	private int expirationMs;
+}
+

--- a/src/main/java/com/almondia/meca/common/configuration/security/MethodSecurityConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/configuration/security/MethodSecurityConfiguration.java
@@ -1,0 +1,23 @@
+package com.almondia.meca.common.configuration.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
+public class MethodSecurityConfiguration extends GlobalMethodSecurityConfiguration {
+
+	@Override
+	protected MethodSecurityExpressionHandler createExpressionHandler() {
+		DefaultMethodSecurityExpressionHandler expressionHandler =
+			new DefaultMethodSecurityExpressionHandler();
+		RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
+		roleHierarchy.setHierarchy("ROLE_ADMIN > ROLE_MANAGER > ROLE_USER");
+		expressionHandler.setRoleHierarchy(roleHierarchy);
+		return expressionHandler;
+	}
+}

--- a/src/main/java/com/almondia/meca/common/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/configuration/security/SecurityConfiguration.java
@@ -1,0 +1,50 @@
+package com.almondia.meca.common.configuration.security;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.almondia.meca.common.configuration.security.filter.JwtAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class SecurityConfiguration {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+		httpSecurity
+			.csrf().disable()
+			.formLogin().disable()
+			.httpBasic().disable()
+			.headers().disable()
+			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.and()
+			.cors();
+		httpSecurity.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+		return httpSecurity.build();
+	}
+
+	@Bean
+	CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE"));
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+}

--- a/src/main/java/com/almondia/meca/common/configuration/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/almondia/meca/common/configuration/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.almondia.meca.common.configuration.security.filter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.almondia.meca.auth.jwt.service.JwtTokenService;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.entity.Member;
+import com.almondia.meca.member.service.MemberService;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	private final JwtTokenService jwtTokenService;
+	private final MemberService memberService;
+
+	@Override
+	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
+		@NonNull FilterChain filterChain) throws ServletException, IOException {
+
+		String accessToken = parseJwtAccessToken(request);
+		if (accessToken != null && !jwtTokenService.isValidToken(accessToken)) {
+			SecurityContextHolder.clearContext();
+			response.setStatus(HttpStatus.UNAUTHORIZED.value());
+			response.sendError(HttpStatus.UNAUTHORIZED.value(), "invalid access token");
+			return;
+		}
+		if (accessToken != null && jwtTokenService.isValidToken(accessToken)) {
+			String memberId = jwtTokenService.getIdFromToken(accessToken);
+			Member member = memberService.findMember(new Id(memberId));
+			SecurityContextHolder.getContext().setAuthentication(makeToken(member));
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private UsernamePasswordAuthenticationToken makeToken(Member member) {
+		List<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(new SimpleGrantedAuthority(member.getRole().getDetails()));
+		return new UsernamePasswordAuthenticationToken(member, "",
+			authorities);
+	}
+
+	private String parseJwtAccessToken(HttpServletRequest request) {
+		String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+		if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+			return authorizationHeader.substring(7);
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/almondia/meca/common/error/ErrorResponseDto.java
+++ b/src/main/java/com/almondia/meca/common/error/ErrorResponseDto.java
@@ -1,0 +1,14 @@
+package com.almondia.meca.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ErrorResponseDto {
+	private String message;
+
+	public static ErrorResponseDto of(Exception exception) {
+		return new ErrorResponseDto(exception.getMessage());
+	}
+}

--- a/src/main/java/com/almondia/meca/common/error/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/almondia/meca/common/error/GlobalControllerExceptionHandler.java
@@ -19,4 +19,9 @@ public class GlobalControllerExceptionHandler {
 	public ResponseEntity<ErrorResponseDto> handleBadWebClientResponseException(BadWebClientResponseException e) {
 		return ResponseEntity.internalServerError().body(ErrorResponseDto.of(e));
 	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponseDto> handleIllegalArgumentException(IllegalArgumentException e) {
+		return ResponseEntity.badRequest().body(ErrorResponseDto.of(e));
+	}
 }

--- a/src/main/java/com/almondia/meca/common/error/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/almondia/meca/common/error/GlobalControllerExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.almondia.meca.common.error;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.almondia.meca.auth.oauth.exception.BadWebClientRequestException;
+import com.almondia.meca.auth.oauth.exception.BadWebClientResponseException;
+
+@RestControllerAdvice
+public class GlobalControllerExceptionHandler {
+
+	@ExceptionHandler(BadWebClientRequestException.class)
+	public ResponseEntity<ErrorResponseDto> handleBadWebClientRequestException(BadWebClientRequestException e) {
+		return ResponseEntity.badRequest().body(ErrorResponseDto.of(e));
+	}
+
+	@ExceptionHandler(BadWebClientResponseException.class)
+	public ResponseEntity<ErrorResponseDto> handleBadWebClientResponseException(BadWebClientResponseException e) {
+		return ResponseEntity.internalServerError().body(ErrorResponseDto.of(e));
+	}
+}

--- a/src/main/java/com/almondia/meca/common/error/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/almondia/meca/common/error/GlobalControllerExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.almondia.meca.common.error;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,7 +13,7 @@ public class GlobalControllerExceptionHandler {
 
 	@ExceptionHandler(BadWebClientRequestException.class)
 	public ResponseEntity<ErrorResponseDto> handleBadWebClientRequestException(BadWebClientRequestException e) {
-		return ResponseEntity.badRequest().body(ErrorResponseDto.of(e));
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponseDto.of(e));
 	}
 
 	@ExceptionHandler(BadWebClientResponseException.class)

--- a/src/main/java/com/almondia/meca/member/repository/MemberRepository.java
+++ b/src/main/java/com/almondia/meca/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.almondia.meca.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Id> {
+}

--- a/src/main/java/com/almondia/meca/member/service/MemberService.java
+++ b/src/main/java/com/almondia/meca/member/service/MemberService.java
@@ -1,0 +1,37 @@
+package com.almondia.meca.member.service;
+
+import org.springframework.stereotype.Service;
+
+import com.almondia.meca.auth.oauth.infra.attribute.OAuth2UserAttribute;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.entity.Member;
+import com.almondia.meca.member.domain.vo.Email;
+import com.almondia.meca.member.domain.vo.Name;
+import com.almondia.meca.member.domain.vo.Role;
+import com.almondia.meca.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public Member save(OAuth2UserAttribute oauth2UserAttribute) {
+		Member member = Member.builder()
+			.memberId(Id.generateNextId())
+			.name(new Name(oauth2UserAttribute.getName()))
+			.oAuthType(oauth2UserAttribute.getOauthType())
+			.email(new Email(oauth2UserAttribute.getEmail()))
+			.role(Role.USER)
+			.build();
+		memberRepository.save(member);
+		return member;
+	}
+
+	public Member findMember(Id memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다"));
+	}
+}

--- a/src/test/java/com/almondia/meca/auth/AuthControllerTest.java
+++ b/src/test/java/com/almondia/meca/auth/AuthControllerTest.java
@@ -28,7 +28,7 @@ import com.almondia.meca.member.service.MemberService;
 
 /**
  *  1. 요청 성공시 AccessTokenResponseDto 속성에 담긴 값이 모두 출력되야 하며 snakeCase여야 함 성공 응답은 200
- *  2. oauth api 요청에 문제가 생긴 경우 400 응답
+ *  2. oauth api 요청에 문제가 생긴 경우 401 응답
  *  3. oauth api 서버에 문제가 생겨 응답에 지장이 생긴 경우 500 응답
  *  4. 사용자 입력 오류시 400 반환
  */
@@ -65,7 +65,7 @@ class AuthControllerTest {
 	}
 
 	@Test
-	@DisplayName("oauth api 요청에 문제가 생긴 경우 400 응답")
+	@DisplayName("oauth api 요청에 문제가 생긴 경우 401 응답")
 	void shouldThrow400WhenExternalApiFailBecauseOfClientFault() throws Exception {
 		Mockito.doThrow(new BadWebClientRequestException("bad request"))
 			.when(oauth2Service).requestUserInfo(anyString(), anyString());
@@ -73,7 +73,7 @@ class AuthControllerTest {
 		mockMvc.perform(post("/api/v1/oauth/login/{registrationId}", "kakao")
 				.param("code", "authorizeCode")
 				.contentType(MediaType.APPLICATION_JSON))
-			.andExpect(status().isBadRequest())
+			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("message").exists());
 	}
 

--- a/src/test/java/com/almondia/meca/auth/AuthControllerTest.java
+++ b/src/test/java/com/almondia/meca/auth/AuthControllerTest.java
@@ -30,6 +30,7 @@ import com.almondia.meca.member.service.MemberService;
  *  1. 요청 성공시 AccessTokenResponseDto 속성에 담긴 값이 모두 출력되야 하며 snakeCase여야 함 성공 응답은 200
  *  2. oauth api 요청에 문제가 생긴 경우 400 응답
  *  3. oauth api 서버에 문제가 생겨 응답에 지장이 생긴 경우 500 응답
+ *  4. 사용자 입력 오류시 400 반환
  */
 @WebMvcTest({AuthController.class})
 @Import({SecurityConfiguration.class, JacksonConfiguration.class})
@@ -86,6 +87,19 @@ class AuthControllerTest {
 				.param("code", "authorizeCode")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("message").exists());
+	}
+
+	@Test
+	@DisplayName("사용자 입력 오류시 400 반환")
+	void shouldThrow400WhenUserBadRequestTest() throws Exception {
+		Mockito.doThrow(new IllegalArgumentException("bad request"))
+			.when(oauth2Service).requestUserInfo(anyString(), anyString());
+
+		mockMvc.perform(post("/api/v1/oauth/login/{registrationId}", "kakao")
+				.param("code", "authorizeCode")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("message").exists());
 	}
 }

--- a/src/test/java/com/almondia/meca/auth/AuthControllerTest.java
+++ b/src/test/java/com/almondia/meca/auth/AuthControllerTest.java
@@ -1,0 +1,91 @@
+package com.almondia.meca.auth;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.almondia.meca.auth.jwt.service.JwtTokenService;
+import com.almondia.meca.auth.oauth.exception.BadWebClientRequestException;
+import com.almondia.meca.auth.oauth.exception.BadWebClientResponseException;
+import com.almondia.meca.auth.oauth.infra.attribute.OAuth2UserAttribute;
+import com.almondia.meca.auth.oauth.service.Oauth2Service;
+import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
+import com.almondia.meca.common.configuration.security.SecurityConfiguration;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.entity.Member;
+import com.almondia.meca.member.domain.vo.OAuthType;
+import com.almondia.meca.member.service.MemberService;
+
+/**
+ *  1. 요청 성공시 AccessTokenResponseDto 속성에 담긴 값이 모두 출력되야 하며 snakeCase여야 함 성공 응답은 200
+ *  2. oauth api 요청에 문제가 생긴 경우 400 응답
+ *  3. oauth api 서버에 문제가 생겨 응답에 지장이 생긴 경우 500 응답
+ */
+@WebMvcTest({AuthController.class})
+@Import({SecurityConfiguration.class, JacksonConfiguration.class})
+class AuthControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	MemberService memberService;
+
+	@MockBean
+	JwtTokenService jwtTokenService;
+
+	@MockBean
+	Oauth2Service oauth2Service;
+
+	@Test
+	@DisplayName("요청 성공시 AccessTokenResponseDto 속성에 담긴 값이 모두 출력되야 하며 snakeCase여야 함 성공 응답은 200")
+	void shouldReturnAccessTokenResponseDtoAllPropertiesAndResponseStatusUsingSnakeCaseTest() throws Exception {
+		Mockito.doReturn(Member.builder().memberId(Id.generateNextId()).build()).when(memberService).save(any());
+		Mockito.doReturn(OAuth2UserAttribute.of("hello", "hello@naver.com", OAuthType.GOOGLE))
+			.when(oauth2Service)
+			.requestUserInfo(eq("kakao"), anyString());
+		Mockito.doReturn("access token").when(jwtTokenService).createToken(any());
+
+		mockMvc.perform(post("/api/v1/oauth/login/{registrationId}", "kakao")
+				.param("code", "authorizeCode")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.access_token").exists());
+	}
+
+	@Test
+	@DisplayName("oauth api 요청에 문제가 생긴 경우 400 응답")
+	void shouldThrow400WhenExternalApiFailBecauseOfClientFault() throws Exception {
+		Mockito.doThrow(new BadWebClientRequestException("bad request"))
+			.when(oauth2Service).requestUserInfo(anyString(), anyString());
+
+		mockMvc.perform(post("/api/v1/oauth/login/{registrationId}", "kakao")
+				.param("code", "authorizeCode")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("message").exists());
+	}
+
+	@Test
+	@DisplayName("oauth api 서버에 문제가 생겨 응답에 지장이 생긴 경우 500 응답")
+	void shouldThrow500WhenExternalApiFailBecauseOfClientFault() throws Exception {
+		Mockito.doThrow(new BadWebClientResponseException("bad response"))
+			.when(oauth2Service).requestUserInfo(anyString(), anyString());
+
+		mockMvc.perform(post("/api/v1/oauth/login/{registrationId}", "kakao")
+				.param("code", "authorizeCode")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("message").exists());
+	}
+}

--- a/src/test/java/com/almondia/meca/auth/jwt/service/JwtTokenServiceTest.java
+++ b/src/test/java/com/almondia/meca/auth/jwt/service/JwtTokenServiceTest.java
@@ -1,0 +1,55 @@
+package com.almondia.meca.auth.jwt.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.almondia.meca.common.configuration.jwt.JwtProperties;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 1. jjwt 라이브러리를 활용한 토큰 생성 및 검증 테스트
+ * 2. 토큰 검증 메서드는 예외를 출력하면 안된다.
+ * 3. token을 통해 성공적으로 ID 문자열 값을 가져와야 한다
+ */
+class JwtTokenServiceTest {
+
+	JwtTokenService tokenService;
+
+	@BeforeEach
+	void before() {
+		JwtProperties fakeJwtProperties = new JwtProperties();
+		fakeJwtProperties.setSecretKey(
+			"asdfasdafd13123132asasdfasdfasdfasdfasdfAdqweqasdfasdafd13123132asasdfasdfasdfasdfasdfAdqweqasdfasdafd13123132asasdfasdfasdfasdfasdfAdqweq");
+		fakeJwtProperties.setExpirationMs(86400000);
+		tokenService = new JwtTokenService(fakeJwtProperties);
+	}
+
+	@Test
+	@DisplayName("생선된 토큰이 유효한 토큰인지 검증")
+	void makeValidTokenTest() {
+		Id id = Id.generateNextId();
+		String token = tokenService.createToken(id);
+		boolean isValid = tokenService.isValidToken(token);
+		assertThat(isValid).isTrue();
+	}
+
+	@Test
+	@DisplayName("토큰 검증은 예외가 아닌 불리언 값을 리턴해야 한다")
+	void shouldReturnBooleanWhenCheckValidTokenTest() {
+		boolean isValid = tokenService.isValidToken("asd123");
+		assertThat(isValid).isFalse();
+	}
+
+	@Test
+	@DisplayName("생성한 jwt token을 추출했을 때 결과는 같아야 한다")
+	void shouldSameIdFromAccessTokenTest() {
+		Id id = Id.generateNextId();
+		String token = tokenService.createToken(id);
+		String id2 = tokenService.getIdFromToken(token);
+		assertThat(id2).isEqualTo(id.toString());
+	}
+
+}

--- a/src/test/java/com/almondia/meca/auth/oauth/infra/CustomOAuth2ClientTest.java
+++ b/src/test/java/com/almondia/meca/auth/oauth/infra/CustomOAuth2ClientTest.java
@@ -1,0 +1,122 @@
+package com.almondia.meca.auth.oauth.infra;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.almondia.meca.auth.oauth.infra.dto.OAuth2AccessTokenResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * 1. 서버에 access token 요청시 성공하면 CustomTokenResponse 형태로 반환받을 수 있어야 함.
+ */
+class CustomOAuth2ClientTest {
+
+	static final String CLIENT_ID = "client";
+	static final String CLIENT_SECRET = "secret";
+	static final String REDIRECT_URI = "https://localhost:3000/callback";
+	static final String SCOPE = "email";
+
+	ObjectMapper objectMapper = new ObjectMapper();
+	WebClient webClient;
+	CustomOAuth2Client oauth2Client;
+	MockWebServer mockWebServer;
+
+	@BeforeEach
+	void before() throws IOException {
+		mockWebServer = new MockWebServer();
+		mockWebServer.setDispatcher(makeDispatcher());
+		mockWebServer.start();
+		ClientRegistration kakao = makeClientRegistration("kakao");
+		FakeClientRegistrationRepository repository = new FakeClientRegistrationRepository();
+		repository.addRegistration(kakao);
+		webClient = WebClient.builder().build();
+		oauth2Client = new CustomOAuth2Client(repository, webClient);
+	}
+
+	@AfterEach
+	void after() throws IOException {
+		mockWebServer.shutdown();
+	}
+
+	@Test
+	@DisplayName("서버에 token 요청 성공시 OAuth2TokenResponse.class형태로 응답이 잘 되는지 검증")
+	void requestAccessTokenSuccessTest() {
+		Mono<OAuth2AccessTokenResponse> response = oauth2Client.requestAccessToken("kakao",
+			"authorization code");
+
+		StepVerifier.create(response)
+			.consumeNextWith(oAuth2AccessTokenResponse ->
+				assertThat(oAuth2AccessTokenResponse).isNotNull())
+			.verifyComplete();
+	}
+
+	@Test
+	void test() {
+
+	}
+
+	private ClientRegistration makeClientRegistration(String registrationId) {
+		return ClientRegistration.withRegistrationId(registrationId)
+			.clientId(CLIENT_ID)
+			.clientSecret(CLIENT_SECRET)
+			.clientName(registrationId)
+			.tokenUri(mockWebServer.url("/token").uri().toString())
+			.userInfoUri(mockWebServer.url("/user").uri().toString())
+			.scope(SCOPE)
+			.redirectUri(REDIRECT_URI)
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.authorizationUri(mockWebServer.url("/authorize").uri().toString())
+			.build();
+	}
+
+	private OAuth2AccessTokenResponse makeTokenResponse() {
+		return OAuth2AccessTokenResponse.builder()
+			.accessToken("adfadfafasd")
+			.refreshToken("asdadfa")
+			.expiresIn(2014231L)
+			.scope("email")
+			.tokenType("authorization_code")
+			.build();
+	}
+
+	private Dispatcher makeDispatcher() throws JsonProcessingException {
+		String jsonResponse = objectMapper.writeValueAsString(makeTokenResponse());
+		return new Dispatcher() {
+			@NotNull
+			@Override
+			public MockResponse dispatch(@NotNull RecordedRequest recordedRequest) {
+				String path = recordedRequest.getPath();
+				assert path != null;
+				if (path.contains("token")) {
+					return new MockResponse()
+						.setResponseCode(HttpStatus.OK.value())
+						.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+						.setBody(jsonResponse);
+				}
+				return new MockResponse()
+					.setResponseCode(HttpStatus.NOT_FOUND.value());
+			}
+		};
+	}
+}

--- a/src/test/java/com/almondia/meca/auth/oauth/infra/FakeClientRegistrationRepository.java
+++ b/src/test/java/com/almondia/meca/auth/oauth/infra/FakeClientRegistrationRepository.java
@@ -1,0 +1,21 @@
+package com.almondia.meca.auth.oauth.infra;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+public class FakeClientRegistrationRepository implements ClientRegistrationRepository {
+
+	private final Map<String, ClientRegistration> map = new HashMap<>();
+
+	public void addRegistration(ClientRegistration clientRegistration) {
+		map.put(clientRegistration.getRegistrationId(), clientRegistration);
+	}
+
+	@Override
+	public ClientRegistration findByRegistrationId(String registrationId) {
+		return map.get(registrationId);
+	}
+}

--- a/src/test/java/com/almondia/meca/auth/oauth/service/Oauth2ServiceTest.java
+++ b/src/test/java/com/almondia/meca/auth/oauth/service/Oauth2ServiceTest.java
@@ -1,0 +1,43 @@
+package com.almondia.meca.auth.oauth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.almondia.meca.auth.oauth.exception.BadWebClientRequestException;
+import com.almondia.meca.auth.oauth.infra.CustomOAuth2Client;
+import com.almondia.meca.auth.oauth.infra.dto.OAuth2AccessTokenResponse;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * 1. 외부 API 소통에 문제가 생기면 WebClient 관련 커스텀 Exception을 발생함
+ */
+class Oauth2ServiceTest {
+
+	CustomOAuth2Client customOAuth2Client = Mockito.mock(CustomOAuth2Client.class);
+	Oauth2Service oAuth2Service = new Oauth2Service(customOAuth2Client);
+
+	@Test
+	void throwExceptionTestWhenRequestAccessTokenThrow() {
+		Mockito.doThrow(new BadWebClientRequestException("bad Request"))
+			.when(customOAuth2Client)
+			.requestAccessToken(eq("kakao"), anyString());
+		assertThatThrownBy(() -> oAuth2Service.requestUserInfo("kakao", "asdf")).isInstanceOf(
+			BadWebClientRequestException.class);
+	}
+
+	@Test
+	void throwExceptionTestWhenRequestUserInfoTokenThrow() {
+		Mockito.doReturn(Mono.just(OAuth2AccessTokenResponse.builder().build()))
+			.when(customOAuth2Client)
+			.requestAccessToken(eq("kakao"), anyString());
+		Mockito.doThrow(new BadWebClientRequestException("bad Request"))
+			.when(customOAuth2Client)
+			.requestUserInfo(eq("kakao"), any());
+		assertThatThrownBy(() -> oAuth2Service.requestUserInfo("kakao", "asdf")).isInstanceOf(
+			BadWebClientRequestException.class);
+	}
+}

--- a/src/test/java/com/almondia/meca/common/configuration/AppConfigurationTest.java
+++ b/src/test/java/com/almondia/meca/common/configuration/AppConfigurationTest.java
@@ -22,6 +22,10 @@ import okhttp3.mockwebserver.RecordedRequest;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+/**
+ * 1. 성공시 정상 응답 테스트
+ * 2. timeout 4초 이상 걸릴 시 실패
+ */
 @ExtendWith(SpringExtension.class)
 @Import(AppConfiguration.class)
 class AppConfigurationTest {

--- a/src/test/java/com/almondia/meca/common/configuration/AppConfigurationTest.java
+++ b/src/test/java/com/almondia/meca/common/configuration/AppConfigurationTest.java
@@ -1,0 +1,89 @@
+package com.almondia.meca.common.configuration;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(SpringExtension.class)
+@Import(AppConfiguration.class)
+class AppConfigurationTest {
+
+	@Autowired
+	WebClient webClient;
+
+	static MockWebServer mockWebServer;
+
+	@BeforeAll
+	static void setUp() throws IOException {
+		mockWebServer = new MockWebServer();
+		setMockServer();
+		mockWebServer.start();
+	}
+
+	@AfterAll
+	static void tearDown() throws IOException {
+		mockWebServer.shutdown();
+	}
+
+	@Test
+	void successTest() {
+		Mono<String> response = webClient.get()
+			.uri(mockWebServer.url("/v1/success").uri())
+			.retrieve()
+			.bodyToMono(String.class);
+
+		StepVerifier.create(response)
+			.expectNext("success")
+			.verifyComplete();
+	}
+
+	@Test
+	void timeoutTest() {
+		Mono<String> response = webClient.get()
+			.uri(mockWebServer.url("v1/timeout").uri())
+			.retrieve()
+			.bodyToMono(String.class);
+
+		StepVerifier.create(response)
+			.verifyError();
+	}
+
+	private static void setMockServer() {
+		Dispatcher dispatcher = new Dispatcher() {
+			@NotNull
+			@Override
+			public MockResponse dispatch(RecordedRequest request) {
+				switch (Objects.requireNonNull(request.getPath())) {
+					case "/v1/timeout":
+						return new MockResponse()
+							.setResponseCode(HttpStatus.OK.value())
+							.setHeadersDelay(6L, TimeUnit.SECONDS);
+					case "/v1/success":
+						return new MockResponse()
+							.setResponseCode(HttpStatus.OK.value())
+							.setBody("success");
+				}
+				return new MockResponse().setResponseCode(HttpStatus.NOT_FOUND.value());
+			}
+		};
+		mockWebServer.setDispatcher(dispatcher);
+	}
+}

--- a/src/test/java/com/almondia/meca/common/configuration/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/almondia/meca/common/configuration/security/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,96 @@
+package com.almondia.meca.common.configuration.security.filter;
+
+import static org.mockito.ArgumentMatchers.*;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.almondia.meca.auth.jwt.service.JwtTokenService;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.entity.Member;
+import com.almondia.meca.member.domain.vo.Email;
+import com.almondia.meca.member.domain.vo.Name;
+import com.almondia.meca.member.domain.vo.OAuthType;
+import com.almondia.meca.member.domain.vo.Role;
+import com.almondia.meca.member.service.MemberService;
+
+/**
+ * 1. 해당 필터는 access token이 입력되지 않았다면 그냥 통과한다
+ * 2. access token이 존재할 떄 옳바르지 않다면 response에 에러를 넣고 401상태를 응답하며 더 이상 필터를 통과시키지 않는다
+ * 3. access token이 정상적이라면 securityContextHolder에 authentication을 등록하고 필터를 통과시킨다
+ */
+class JwtAuthenticationFilterTest {
+
+	static JwtAuthenticationFilter jwtAuthenticationFilter;
+	static JwtTokenService jwtTokenService;
+	static MemberService memberService;
+	HttpServletRequest request;
+	HttpServletResponse response;
+	FilterChain filterChain;
+
+	@BeforeAll
+	static void setUp() {
+		jwtTokenService = Mockito.mock(JwtTokenService.class);
+		memberService = Mockito.mock(MemberService.class);
+		jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenService, memberService);
+		Mockito.doReturn(Member.builder()
+			.memberId(Id.generateNextId())
+			.email(new Email("emial@naver.com"))
+			.name(new Name("name"))
+			.oAuthType(OAuthType.KAKAO)
+			.role(Role.USER)
+			.build()).when(memberService).findMember(any());
+	}
+
+	@BeforeEach
+	void initialize() {
+		request = Mockito.mock(HttpServletRequest.class);
+		response = Mockito.mock(HttpServletResponse.class);
+		filterChain = Mockito.mock(FilterChain.class);
+	}
+
+	@Test
+	@DisplayName("해당 필터는 access token이 입력되지 않았다면 그냥 통과한다")
+	void shouldPassWhenNotInputAccessTokenTest() throws ServletException, IOException {
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+		Mockito.verify(filterChain, Mockito.atLeastOnce()).doFilter(request, response);
+	}
+
+	@Test
+	@DisplayName("access token이 존재할 떄 옳바르지 않다면 response에 에러를 넣고 401상태를 응답하며 더 이상 필터를 통과시키지 않는다")
+	void shouldBlockAndErrorResponseWhenNotInputAccessTokenTest() throws ServletException, IOException {
+		String invalidAccessToken = "asa";
+		Mockito.doReturn("Bearer " + invalidAccessToken).when(request).getHeader("Authorization");
+
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+		Mockito.verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		Mockito.verify(filterChain, Mockito.never()).doFilter(request, response);
+	}
+
+	@Test
+	@DisplayName("access token이 정상적이라면 securityContextHolder에 authentication을 등록하고 필터를 통과시킨다")
+	void shouldPassBlockAndAddAuthenticationIntoSecurityContextWhenAccessTokenIsValidTest() throws
+		ServletException,
+		IOException {
+
+		String validToken = "asda1231aad";
+		Mockito.doReturn(true).when(jwtTokenService).isValidToken(validToken);
+		Mockito.doReturn(Id.generateNextId().toString()).when(jwtTokenService).getIdFromToken(validToken);
+		Mockito.doReturn("Bearer " + validToken).when(request).getHeader("Authorization");
+
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+		Mockito.verify(filterChain, Mockito.atLeastOnce()).doFilter(request, response);
+	}
+}

--- a/src/test/java/com/almondia/meca/member/service/MemberServiceTest.java
+++ b/src/test/java/com/almondia/meca/member/service/MemberServiceTest.java
@@ -1,0 +1,75 @@
+package com.almondia.meca.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.almondia.meca.auth.oauth.infra.attribute.OAuth2UserAttribute;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.entity.Member;
+import com.almondia.meca.member.domain.vo.Email;
+import com.almondia.meca.member.domain.vo.Name;
+import com.almondia.meca.member.domain.vo.OAuthType;
+import com.almondia.meca.member.domain.vo.Role;
+import com.almondia.meca.member.repository.MemberRepository;
+
+/**
+ * 1. saveOAuthAttribute 요청시 성공적으로 회원을 db에 저장해야한다.
+ * 2. findMember 요청시 없다면 IllegalArgumentException 예외 출력
+ * 3. findMember 요청시 있다면 Member 반환
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({MemberService.class})
+class MemberServiceTest {
+
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Autowired
+	MemberService memberService;
+
+	@Test
+	@DisplayName("save 요청시 oauth2UserAttribute 정보가 db에 저장된다")
+	void shouldSaveDbTestWhenCallSaveOAuthAttributeTest() {
+		OAuth2UserAttribute oAuth2UserAttribute = new OAuth2UserAttribute("hello", "marrin1101@naver.com",
+			OAuthType.NAVER);
+		memberService.save(oAuth2UserAttribute);
+		List<Member> all = memberRepository.findAll();
+		assertThat(all).isNotEmpty();
+	}
+
+	@Test
+	@DisplayName("findMember 요청시 없다면 예외 발생")
+	void shouldThrowExceptionWhenNotFoundEntityTest() {
+		assertThatThrownBy(() -> memberService.findMember(Id.generateNextId()))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("findMember 요청시 있다면 해당 entity 출력")
+	void shouldReturnEntityWhenCallFindMemberTest() {
+		Id id = Id.generateNextId();
+		Member member = Member.builder()
+			.memberId(id)
+			.oAuthType(OAuthType.KAKAO)
+			.name(new Name("hello"))
+			.email(new Email("hello@naver.com"))
+			.role(Role.USER)
+			.build();
+		memberRepository.save(member);
+		Member result = memberService.findMember(id);
+		assertThat(result).hasFieldOrProperty("memberId")
+			.hasFieldOrProperty("oAuthType")
+			.hasFieldOrProperty("name")
+			.hasFieldOrProperty("role")
+			.hasFieldOrProperty("email");
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,3 +12,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         show_sql: true
         format_sql: true
+
+jwt:
+  secretKey: asdfasdafd13123132asasdfasdfasdfasdfasdfAdqweqasdfasdafd13123132asasdfasdfasdfasdfasdfAdqweqasdfasdafd13123132asasdfasdfasdfasdfasdfAdqweq
+  expirationMs: 86400000

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,57 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         show_sql: true
         format_sql: true
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            clientId: ~~~
+            clientSecret: ~~~
+            redirectUri: ~~~
+            authorization-grant-type: ~~~
+            client-authentication-method: ~~~
+            clientName: ~~~
+            scope:
+              - profile
+              - email
+          kakao:
+            client-id: ~~~
+            client-secret: ~~~
+            redirect-uri: ~~~
+            authorization-grant-type: ~~~
+            client-authentication-method: ~~~
+            client-name: ~~~
+            scope:
+              - profile
+              - account_email
+          naver:
+            clientId: ~~~
+            clientSecret: ~~~
+            redirect-uri: ~~~
+            authorization-grant-type: ~~~
+            client-authentication-method: ~~~
+            client-name: ~~~
+            scope:
+              - profile
+              - account_email
+
+        provider:
+          kakao:
+            authorizationUri: ~~~
+            token-uri: ~~~
+            user-info-uri: ~~~
+            user-name-attribute: ~~~
+          naver:
+            authorizationUri: ~~~
+            token-uri: ~~~
+            user-info-uri: ~~~
+            user-name-attribute: ~~~
+          google:
+            authorizationUri: ~~~
+            token-uri: ~~~
+            userInfoUri: ~~~
+            userNameAttribute: ~~~
 
 jwt:
   secretKey: asdfasdafd13123132asasdfasdfasdfasdfasdfAdqweqasdfasdafd13123132asasdfasdfasdfasdfasdfAdqweqasdfasdafd13123132asasdfasdfasdfasdfasdfAdqweq


### PR DESCRIPTION
## 요약

- oauth 서버에 직접 접근 가능한 객체 구현
- RestTemplate 대신 WebClient 사용
- json, webflux, mock web server, reactor test 의존성 추가
- 커스텀 exception 및 이를 처리할 글로벌 exceptionHandler 구현
- access token 인증 방식은 jwt을 활용한 방식으로 진행
- 메소드 시큐리티 적용


## 유의사항

- cors를 직접 테스트 못해봄