### PR TITLE
feat/#15: 카드 등록 API 추가

### DIFF
--- a/src/main/java/com/almondia/meca/card/controller/CardController.java
+++ b/src/main/java/com/almondia/meca/card/controller/CardController.java
@@ -1,0 +1,30 @@
+package com.almondia.meca.card.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.almondia.meca.card.controller.dto.CardResponseDto;
+import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
+import com.almondia.meca.card.sevice.CardService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/cards")
+@RequiredArgsConstructor
+public class CardController {
+
+	private final CardService cardService;
+
+	@Secured("ROLE_USER")
+	@PostMapping
+	public ResponseEntity<CardResponseDto> saveCard(@RequestBody SaveCardRequestDto saveCardRequestDto) {
+		CardResponseDto cardResponseDto = cardService.saveCard(saveCardRequestDto);
+		return ResponseEntity.status(HttpStatus.CREATED).body(cardResponseDto);
+	}
+}

--- a/src/main/java/com/almondia/meca/card/controller/dto/CardResponseDto.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/CardResponseDto.java
@@ -1,0 +1,36 @@
+package com.almondia.meca.card.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.Image;
+import com.almondia.meca.card.domain.vo.KeywordAnswer;
+import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
+import com.almondia.meca.card.domain.vo.OxAnswer;
+import com.almondia.meca.card.domain.vo.Question;
+import com.almondia.meca.card.domain.vo.Title;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+public class CardResponseDto {
+
+	private final Id cardId;
+	private final Title title;
+	private final Question question;
+	private final List<Image> images;
+	private final Id categoryId;
+	private final CardType cardType;
+	private final boolean isDeleted;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime modifiedAt;
+	private final OxAnswer oxAnswer;
+	private final KeywordAnswer keywordAnswer;
+	private final MultiChoiceAnswer multiChoiceAnswer;
+}

--- a/src/main/java/com/almondia/meca/card/controller/dto/SaveCardRequestDto.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/SaveCardRequestDto.java
@@ -1,0 +1,28 @@
+package com.almondia.meca.card.controller.dto;
+
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.KeywordAnswer;
+import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
+import com.almondia.meca.card.domain.vo.OxAnswer;
+import com.almondia.meca.card.domain.vo.Question;
+import com.almondia.meca.card.domain.vo.Title;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+public class SaveCardRequestDto {
+
+	private final Title title;
+	private final Question question;
+	private final Id categoryId;
+	private final String images;
+	private final CardType cardType;
+	private final OxAnswer oxAnswer;
+	private final KeywordAnswer keywordAnswer;
+	private final MultiChoiceAnswer multiChoiceAnswer;
+}

--- a/src/main/java/com/almondia/meca/card/controller/dto/SaveCardRequestDto.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/SaveCardRequestDto.java
@@ -8,21 +8,24 @@ import com.almondia.meca.card.domain.vo.Question;
 import com.almondia.meca.card.domain.vo.Title;
 import com.almondia.meca.common.domain.vo.Id;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
-@RequiredArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SaveCardRequestDto {
 
-	private final Title title;
-	private final Question question;
-	private final Id categoryId;
-	private final String images;
-	private final CardType cardType;
-	private final OxAnswer oxAnswer;
-	private final KeywordAnswer keywordAnswer;
-	private final MultiChoiceAnswer multiChoiceAnswer;
+	private Title title;
+	private Question question;
+	private Id categoryId;
+	private String images;
+	private CardType cardType;
+	private OxAnswer oxAnswer;
+	private KeywordAnswer keywordAnswer;
+	private MultiChoiceAnswer multiChoiceAnswer;
 }

--- a/src/main/java/com/almondia/meca/card/domain/converter/ListImageConverter.java
+++ b/src/main/java/com/almondia/meca/card/domain/converter/ListImageConverter.java
@@ -1,0 +1,33 @@
+package com.almondia.meca.card.domain.converter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import com.almondia.meca.card.domain.vo.Image;
+
+@Converter
+public class ListImageConverter implements AttributeConverter<List<Image>, String> {
+
+	private static final String SPLIT_CHAR = ",";
+
+	@Override
+	public String convertToDatabaseColumn(List<Image> attribute) {
+		if (attribute == null || attribute.isEmpty()) {
+			return null;
+		}
+		return attribute.stream().map(Image::toString).collect(Collectors.joining(SPLIT_CHAR));
+	}
+
+	@Override
+	public List<Image> convertToEntityAttribute(String dbData) {
+		if (dbData == null) {
+			return Collections.emptyList();
+		}
+		return Arrays.stream(dbData.split(SPLIT_CHAR)).map(Image::new).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/almondia/meca/card/domain/entity/Card.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/Card.java
@@ -1,0 +1,68 @@
+package com.almondia.meca.card.domain.entity;
+
+import java.util.List;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Embedded;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Transient;
+
+import com.almondia.meca.card.domain.converter.ListImageConverter;
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.Image;
+import com.almondia.meca.card.domain.vo.Question;
+import com.almondia.meca.card.domain.vo.Title;
+import com.almondia.meca.common.domain.entity.DateEntity;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn
+@SuperBuilder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Card extends DateEntity {
+
+	@EmbeddedId
+	@AttributeOverride(name = "uuid", column = @Column(name = "card_id", nullable = false, columnDefinition = "BINARY(16)"))
+	Id cardId;
+
+	@Embedded
+	@AttributeOverride(name = "question", column = @Column(name = "question", nullable = false, length = 500))
+	Question question;
+
+	@Embedded
+	Title title;
+
+	@Embedded
+	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, columnDefinition = "BINARY(16)"))
+	Id categoryId;
+
+	@Column(name = "images", length = 1020)
+	@Convert(converter = ListImageConverter.class)
+	private List<Image> images;
+
+	@Transient
+	private CardType cardType;
+
+	private boolean isDeleted;
+
+	public void delete() {
+		isDeleted = true;
+	}
+
+	public void rollback() {
+		isDeleted = false;
+	}
+}

--- a/src/main/java/com/almondia/meca/card/domain/entity/KeywordCard.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/KeywordCard.java
@@ -1,0 +1,25 @@
+package com.almondia.meca.card.domain.entity;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+
+import com.almondia.meca.card.domain.vo.KeywordAnswer;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@DiscriminatorValue("KEYWORD")
+@AllArgsConstructor
+@SuperBuilder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KeywordCard extends Card {
+
+	@Embedded
+	private KeywordAnswer keywordAnswer;
+}

--- a/src/main/java/com/almondia/meca/card/domain/entity/MultiChoiceCard.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/MultiChoiceCard.java
@@ -1,0 +1,28 @@
+package com.almondia.meca.card.domain.entity;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+
+import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@DiscriminatorValue("MULTI_CHOICE")
+@AllArgsConstructor
+@SuperBuilder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MultiChoiceCard extends Card {
+
+	@Embedded
+	@Column(name = "multi_choice_answer", nullable = false)
+	private MultiChoiceAnswer multiChoiceAnswer;
+
+}

--- a/src/main/java/com/almondia/meca/card/domain/entity/OxCard.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/OxCard.java
@@ -1,0 +1,26 @@
+package com.almondia.meca.card.domain.entity;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+import com.almondia.meca.card.domain.vo.OxAnswer;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@DiscriminatorValue("OX_QUIZ")
+@AllArgsConstructor
+@SuperBuilder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OxCard extends Card {
+
+	@Enumerated(EnumType.STRING)
+	private OxAnswer oxAnswer;
+}

--- a/src/main/java/com/almondia/meca/card/domain/vo/CardType.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/CardType.java
@@ -1,0 +1,5 @@
+package com.almondia.meca.card.domain.vo;
+
+public enum CardType {
+	OX_QUIZ, KEYWORD, MULTI_CHOICE
+}

--- a/src/main/java/com/almondia/meca/card/domain/vo/Image.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/Image.java
@@ -1,0 +1,35 @@
+package com.almondia.meca.card.domain.vo;
+
+import javax.persistence.Embeddable;
+
+import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image implements Wrapper {
+
+	private static final int MAX_LINK_LENGTH = 255;
+
+	private String image;
+
+	public Image(String image) {
+		validateImages(image);
+		this.image = image;
+	}
+
+	private void validateImages(String image) {
+		if (image.length() > MAX_LINK_LENGTH) {
+			throw new IllegalArgumentException(String.format("image 링크 길이는 %d를 초과할 수 없습니다", MAX_LINK_LENGTH));
+		}
+	}
+
+	@Override
+	public String toString() {
+		return image;
+	}
+}

--- a/src/main/java/com/almondia/meca/card/domain/vo/KeywordAnswer.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/KeywordAnswer.java
@@ -1,0 +1,30 @@
+package com.almondia.meca.card.domain.vo;
+
+import javax.persistence.Embeddable;
+
+import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KeywordAnswer implements Wrapper {
+
+	private static final int MAX_LENGTH = 255;
+
+	private String keywordAnswer;
+
+	public KeywordAnswer(String keywordAnswer) {
+		validateKeywordAnswer(keywordAnswer);
+		this.keywordAnswer = keywordAnswer;
+	}
+
+	private void validateKeywordAnswer(String keywordAnswer) {
+		if (keywordAnswer.length() > MAX_LENGTH) {
+			throw new IllegalArgumentException("%d 초과해서 문자열 길이를 늘릴 수 없습니다");
+		}
+	}
+}

--- a/src/main/java/com/almondia/meca/card/domain/vo/MultiChoiceAnswer.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/MultiChoiceAnswer.java
@@ -16,7 +16,7 @@ public class MultiChoiceAnswer implements Wrapper {
 	private static final int MAX_NUMBER = 5;
 	private static final int MIN_NUMBER = 1;
 
-	private int number;
+	private Integer number;
 
 	public MultiChoiceAnswer(int number) {
 		validateNumber(number);

--- a/src/main/java/com/almondia/meca/card/domain/vo/MultiChoiceAnswer.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/MultiChoiceAnswer.java
@@ -1,0 +1,31 @@
+package com.almondia.meca.card.domain.vo;
+
+import javax.persistence.Embeddable;
+
+import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MultiChoiceAnswer implements Wrapper {
+
+	private static final int MAX_NUMBER = 5;
+	private static final int MIN_NUMBER = 1;
+
+	private int number;
+
+	public MultiChoiceAnswer(int number) {
+		validateNumber(number);
+		this.number = number;
+	}
+
+	private void validateNumber(int number) {
+		if (number < MIN_NUMBER || number > MAX_NUMBER) {
+			throw new IllegalArgumentException(String.format("%d부터 %d숫자만 입력 가능합니다", MIN_NUMBER, MAX_NUMBER));
+		}
+	}
+}

--- a/src/main/java/com/almondia/meca/card/domain/vo/OxAnswer.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/OxAnswer.java
@@ -1,0 +1,5 @@
+package com.almondia.meca.card.domain.vo;
+
+public enum OxAnswer {
+	O, X
+}

--- a/src/main/java/com/almondia/meca/card/domain/vo/Question.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/Question.java
@@ -1,0 +1,32 @@
+package com.almondia.meca.card.domain.vo;
+
+import javax.persistence.Embeddable;
+
+import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Question implements Wrapper {
+
+	private static final int MAX_LENGTH = 500;
+	private String question;
+
+	public Question(String question) {
+		validateQuestion(question);
+		this.question = question;
+	}
+
+	private void validateQuestion(String question) {
+		if (question.isBlank()) {
+			throw new IllegalArgumentException("퀴즈 문제에 비우거나 공백만 입력해서는 안됩니다");
+		}
+		if (question.length() > MAX_LENGTH) {
+			throw new IllegalArgumentException(String.format("%d를 초과해서 입력하셨습니다", MAX_LENGTH));
+		}
+	}
+}

--- a/src/main/java/com/almondia/meca/card/domain/vo/Title.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/Title.java
@@ -1,0 +1,35 @@
+package com.almondia.meca.card.domain.vo;
+
+import javax.persistence.Embeddable;
+
+import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Title implements Wrapper {
+
+	private static final int TITLE_MAX_LENGTH = 20;
+	private static final int TITLE_MIN_LENGTH = 2;
+
+	private String title;
+
+	public Title(String title) {
+		validateTitle(title);
+		this.title = title;
+	}
+
+	private void validateTitle(String title) {
+		if (title.length() < TITLE_MIN_LENGTH || title.length() > TITLE_MAX_LENGTH) {
+			throw new IllegalArgumentException(
+				String.format("%d 길이이상 %d 길이 이하로 입력해주세요", TITLE_MIN_LENGTH, TITLE_MAX_LENGTH));
+		}
+		if (title.isBlank()) {
+			throw new IllegalArgumentException("공백만 입력할 수 업습니다");
+		}
+	}
+}

--- a/src/main/java/com/almondia/meca/card/repository/KeywordCardRepository.java
+++ b/src/main/java/com/almondia/meca/card/repository/KeywordCardRepository.java
@@ -1,0 +1,9 @@
+package com.almondia.meca.card.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.almondia.meca.card.domain.entity.KeywordCard;
+import com.almondia.meca.common.domain.vo.Id;
+
+public interface KeywordCardRepository extends JpaRepository<KeywordCard, Id> {
+}

--- a/src/main/java/com/almondia/meca/card/repository/MultiChoiceCardRepository.java
+++ b/src/main/java/com/almondia/meca/card/repository/MultiChoiceCardRepository.java
@@ -1,0 +1,9 @@
+package com.almondia.meca.card.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.almondia.meca.card.domain.entity.MultiChoiceCard;
+import com.almondia.meca.common.domain.vo.Id;
+
+public interface MultiChoiceCardRepository extends JpaRepository<MultiChoiceCard, Id> {
+}

--- a/src/main/java/com/almondia/meca/card/repository/OxCardRepository.java
+++ b/src/main/java/com/almondia/meca/card/repository/OxCardRepository.java
@@ -1,0 +1,9 @@
+package com.almondia.meca.card.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.almondia.meca.card.domain.entity.OxCard;
+import com.almondia.meca.common.domain.vo.Id;
+
+public interface OxCardRepository extends JpaRepository<OxCard, Id> {
+}

--- a/src/main/java/com/almondia/meca/card/sevice/CardService.java
+++ b/src/main/java/com/almondia/meca/card/sevice/CardService.java
@@ -1,0 +1,43 @@
+package com.almondia.meca.card.sevice;
+
+import org.springframework.stereotype.Service;
+
+import com.almondia.meca.card.controller.dto.CardResponseDto;
+import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
+import com.almondia.meca.card.domain.entity.Card;
+import com.almondia.meca.card.domain.entity.KeywordCard;
+import com.almondia.meca.card.domain.entity.MultiChoiceCard;
+import com.almondia.meca.card.domain.entity.OxCard;
+import com.almondia.meca.card.repository.KeywordCardRepository;
+import com.almondia.meca.card.repository.MultiChoiceCardRepository;
+import com.almondia.meca.card.repository.OxCardRepository;
+import com.almondia.meca.card.sevice.helper.CardFactory;
+import com.almondia.meca.card.sevice.helper.CardMapper;
+
+import lombok.AllArgsConstructor;
+
+@Service
+@AllArgsConstructor
+public class CardService {
+
+	private final OxCardRepository oxCardRepository;
+	private final KeywordCardRepository keywordCardRepository;
+	private final MultiChoiceCardRepository multiChoiceCardRepository;
+
+	public CardResponseDto saveCard(SaveCardRequestDto saveCardRequestDto) {
+		Card card = CardFactory.genCard(saveCardRequestDto);
+		if (card instanceof OxCard) {
+			OxCard oxCard = oxCardRepository.save((OxCard)card);
+			return CardMapper.oxCardToDto(oxCard);
+		}
+		if (card instanceof KeywordCard) {
+			KeywordCard keywordCard = keywordCardRepository.save((KeywordCard)card);
+			return CardMapper.keywordCardToDto(keywordCard);
+		}
+		if (card instanceof MultiChoiceCard) {
+			MultiChoiceCard multiChoiceCard = multiChoiceCardRepository.save((MultiChoiceCard)card);
+			return CardMapper.multiChoiceCardToDto(multiChoiceCard);
+		}
+		throw new IllegalArgumentException("지원하는 카드 유형이 아닙니다");
+	}
+}

--- a/src/main/java/com/almondia/meca/card/sevice/helper/CardFactory.java
+++ b/src/main/java/com/almondia/meca/card/sevice/helper/CardFactory.java
@@ -1,0 +1,73 @@
+package com.almondia.meca.card.sevice.helper;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
+import com.almondia.meca.card.domain.entity.Card;
+import com.almondia.meca.card.domain.entity.KeywordCard;
+import com.almondia.meca.card.domain.entity.MultiChoiceCard;
+import com.almondia.meca.card.domain.entity.OxCard;
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.Image;
+import com.almondia.meca.common.domain.vo.Id;
+
+public class CardFactory {
+
+	private static final String SPLIT_WORD = ",";
+
+	public static Card genCard(SaveCardRequestDto saveCardRequestDto) {
+		CardType cardType = saveCardRequestDto.getCardType();
+		if (cardType.equals(CardType.OX_QUIZ)) {
+			return genOxCard(saveCardRequestDto);
+		}
+		if (cardType.equals(CardType.KEYWORD)) {
+			return genKeywordCard(saveCardRequestDto);
+		}
+		if (cardType.equals(CardType.MULTI_CHOICE)) {
+			return genMultiChoiceCard(saveCardRequestDto);
+		}
+		throw new IllegalArgumentException("잘못된 cardType 입니다");
+	}
+
+	private static OxCard genOxCard(SaveCardRequestDto saveCardRequestDto) {
+		return OxCard.builder()
+			.cardId(Id.generateNextId())
+			.question(saveCardRequestDto.getQuestion())
+			.title(saveCardRequestDto.getTitle())
+			.categoryId(saveCardRequestDto.getCategoryId())
+			.cardType(saveCardRequestDto.getCardType())
+			.images(makeImages(saveCardRequestDto.getImages()))
+			.oxAnswer(saveCardRequestDto.getOxAnswer())
+			.build();
+	}
+
+	private static KeywordCard genKeywordCard(SaveCardRequestDto saveCardRequestDto) {
+		return KeywordCard.builder()
+			.cardId(Id.generateNextId())
+			.question(saveCardRequestDto.getQuestion())
+			.title(saveCardRequestDto.getTitle())
+			.categoryId(saveCardRequestDto.getCategoryId())
+			.cardType(saveCardRequestDto.getCardType())
+			.images(makeImages(saveCardRequestDto.getImages()))
+			.keywordAnswer(saveCardRequestDto.getKeywordAnswer())
+			.build();
+	}
+
+	private static MultiChoiceCard genMultiChoiceCard(SaveCardRequestDto saveCardRequestDto) {
+		return MultiChoiceCard.builder()
+			.cardId(Id.generateNextId())
+			.question(saveCardRequestDto.getQuestion())
+			.title(saveCardRequestDto.getTitle())
+			.categoryId(saveCardRequestDto.getCategoryId())
+			.cardType(saveCardRequestDto.getCardType())
+			.images(makeImages(saveCardRequestDto.getImages()))
+			.multiChoiceAnswer(saveCardRequestDto.getMultiChoiceAnswer())
+			.build();
+	}
+
+	private static List<Image> makeImages(String images) {
+		return Arrays.stream(images.split(SPLIT_WORD)).map(Image::new).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/almondia/meca/card/sevice/helper/CardMapper.java
+++ b/src/main/java/com/almondia/meca/card/sevice/helper/CardMapper.java
@@ -1,0 +1,54 @@
+package com.almondia.meca.card.sevice.helper;
+
+import com.almondia.meca.card.controller.dto.CardResponseDto;
+import com.almondia.meca.card.domain.entity.KeywordCard;
+import com.almondia.meca.card.domain.entity.MultiChoiceCard;
+import com.almondia.meca.card.domain.entity.OxCard;
+
+public class CardMapper {
+
+	public static CardResponseDto oxCardToDto(OxCard oxCard) {
+		return CardResponseDto.builder()
+			.cardId(oxCard.getCardId())
+			.title(oxCard.getTitle())
+			.question(oxCard.getQuestion())
+			.images(oxCard.getImages())
+			.categoryId(oxCard.getCategoryId())
+			.cardType(oxCard.getCardType())
+			.isDeleted(oxCard.isDeleted())
+			.createdAt(oxCard.getCreatedAt())
+			.modifiedAt(oxCard.getModifiedAt())
+			.oxAnswer(oxCard.getOxAnswer())
+			.build();
+	}
+
+	public static CardResponseDto keywordCardToDto(KeywordCard keywordCard) {
+		return CardResponseDto.builder()
+			.cardId(keywordCard.getCardId())
+			.title(keywordCard.getTitle())
+			.question(keywordCard.getQuestion())
+			.images(keywordCard.getImages())
+			.categoryId(keywordCard.getCategoryId())
+			.cardType(keywordCard.getCardType())
+			.isDeleted(keywordCard.isDeleted())
+			.createdAt(keywordCard.getCreatedAt())
+			.modifiedAt(keywordCard.getModifiedAt())
+			.keywordAnswer(keywordCard.getKeywordAnswer())
+			.build();
+	}
+
+	public static CardResponseDto multiChoiceCardToDto(MultiChoiceCard multiChoiceCard) {
+		return CardResponseDto.builder()
+			.cardId(multiChoiceCard.getCardId())
+			.title(multiChoiceCard.getTitle())
+			.question(multiChoiceCard.getQuestion())
+			.images(multiChoiceCard.getImages())
+			.categoryId(multiChoiceCard.getCategoryId())
+			.cardType(multiChoiceCard.getCardType())
+			.isDeleted(multiChoiceCard.isDeleted())
+			.createdAt(multiChoiceCard.getCreatedAt())
+			.modifiedAt(multiChoiceCard.getModifiedAt())
+			.multiChoiceAnswer(multiChoiceCard.getMultiChoiceAnswer())
+			.build();
+	}
+}

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -1,0 +1,98 @@
+package com.almondia.meca.card.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.almondia.meca.card.controller.dto.CardResponseDto;
+import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.Image;
+import com.almondia.meca.card.domain.vo.OxAnswer;
+import com.almondia.meca.card.domain.vo.Question;
+import com.almondia.meca.card.domain.vo.Title;
+import com.almondia.meca.card.sevice.CardService;
+import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
+import com.almondia.meca.common.configuration.security.filter.JwtAuthenticationFilter;
+import com.almondia.meca.common.domain.vo.Id;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * 1. 요청 성공시 201을 리턴하고 카드 정보를 반환한다.
+ */
+@WebMvcTest(CardController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({JacksonConfiguration.class})
+class CardControllerTest {
+
+	@MockBean
+	CardService cardService;
+
+	@MockBean
+	JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("요청 성공시 201을 리턴하고 카드 정보를 반환한다")
+	void test() throws Exception {
+		SaveCardRequestDto saveCardRequestDto = SaveCardRequestDto.builder()
+			.title(new Title("title"))
+			.question(new Question("hello"))
+			.images("A,B,C,D")
+			.categoryId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.oxAnswer(OxAnswer.O)
+			.build();
+		Mockito.doReturn(makeResponse()).when(cardService).saveCard(any());
+
+		mockMvc.perform(post("/api/v1/cards")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(saveCardRequestDto)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("card_id").exists())
+			.andExpect(jsonPath("title").exists())
+			.andExpect(jsonPath("question").exists())
+			.andExpect(jsonPath("images").exists())
+			.andExpect(jsonPath("category_id").exists())
+			.andExpect(jsonPath("deleted").exists())
+			.andExpect(jsonPath("card_type").exists())
+			.andExpect(jsonPath("created_at").exists())
+			.andExpect(jsonPath("modified_at").exists())
+			.andExpect(jsonPath("title").exists())
+			.andExpect(jsonPath("ox_answer").exists());
+	}
+
+	private CardResponseDto makeResponse() {
+		return CardResponseDto.builder()
+			.cardId(Id.generateNextId())
+			.title(new Title("title"))
+			.question(new Question("hello"))
+			.images(List.of(new Image("A"), new Image("B"), new Image("C")))
+			.categoryId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.isDeleted(false)
+			.oxAnswer(OxAnswer.O)
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.build();
+	}
+}

--- a/src/test/java/com/almondia/meca/card/domain/entity/CardTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/entity/CardTest.java
@@ -1,0 +1,126 @@
+package com.almondia.meca.card.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.metamodel.EntityType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
+
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.Image;
+import com.almondia.meca.card.domain.vo.OxAnswer;
+import com.almondia.meca.card.domain.vo.Question;
+import com.almondia.meca.card.domain.vo.Title;
+import com.almondia.meca.common.configuration.jpa.JpaAuditingConfiguration;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 1. 데이터 속성 생성 테스트
+ * 2. entity를 생성해서 저장시 createdAt과 modifiedAt이 자동으로 업데이트되며 서로 같음
+ * 3. entity 수정시 modifiedAt이 업데이트되며 modifiedAt이 createdAt보다 이후의 날짜여야 함
+ * 4. delete, rollback 메서드 사용시 isDeleted 상태가 변경되어야 함
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfiguration.class})
+class CardTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("데이터 속성 생성 테스트")
+	void oxCardAttributeCreationTest() {
+		EntityType<?> entityType = entityManager.getMetamodel().entity(Card.class);
+		assertThat(entityType).isNotNull();
+		assertThat(entityType.getName()).isEqualTo("Card");
+		assertThat(entityType.getAttributes()).extracting("name")
+			.containsExactlyInAnyOrder("question", "isDeleted", "cardId", "categoryId", "title", "images", "createdAt",
+				"modifiedAt");
+	}
+
+	@Test
+	@DisplayName("entity를 생성해서 저장시 createdAt과 modifiedAt이 자동으로 업데이트되며 서로 같음")
+	void shouldUpdateCreatedAtAndModifiedAtAndTheyAreEqualWhenEntitySave() {
+		JpaRepository<OxCard, Id> oxCardJpaRepository = new SimpleJpaRepository<>(OxCard.class, entityManager);
+		OxCard oxCard = OxCard.builder()
+			.cardId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.question(new Question("Question"))
+			.categoryId(Id.generateNextId())
+			.images(List.of(new Image("image1"), new Image("image2")))
+			.title(new Title("title"))
+			.oxAnswer(OxAnswer.O)
+			.build();
+		oxCardJpaRepository.save(oxCard);
+		OxCard result = oxCardJpaRepository.findById(oxCard.getCardId()).orElseThrow();
+		LocalDateTime createdAt = result.getCreatedAt();
+		LocalDateTime modifiedAt = result.getModifiedAt();
+		assertThat(createdAt).isEqualTo(modifiedAt);
+	}
+
+	@Test
+	@DisplayName("entity 수정시 modifiedAt이 업데이트되며 modifiedAt이 createdAt보다 이후의 날짜여야 함")
+	void shouldUpdateModifiedAtAndModifiedAtAfterThanCreatedAtWhenEntityUpdate() throws InterruptedException {
+		JpaRepository<OxCard, Id> oxCardJpaRepository = new SimpleJpaRepository<>(OxCard.class, entityManager);
+		OxCard oxCard = OxCard.builder()
+			.cardId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.question(new Question("Question"))
+			.categoryId(Id.generateNextId())
+			.images(List.of(new Image("image1"), new Image("image2")))
+			.title(new Title("title"))
+			.oxAnswer(OxAnswer.O)
+			.build();
+		System.out.println(oxCard);
+		oxCardJpaRepository.save(oxCard);
+		OxCard temp = oxCardJpaRepository.findById(oxCard.getCardId()).orElseThrow();
+		temp.delete();
+		oxCardJpaRepository.saveAndFlush(temp);
+		Thread.sleep(100);
+		OxCard result = oxCardJpaRepository.findById(oxCard.getCardId()).orElseThrow();
+		assertThat(result.getModifiedAt()).isAfter(result.getCreatedAt());
+	}
+
+	@Test
+	@DisplayName("delete 메서드시 isDeleted는 false가 true가 되야함")
+	void shouldTrueWhenCallDelete() {
+		OxCard oxCard = OxCard.builder()
+			.cardId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.categoryId(Id.generateNextId())
+			.images(List.of(new Image("image1"), new Image("image2")))
+			.title(new Title("title"))
+			.oxAnswer(OxAnswer.O)
+			.build();
+		oxCard.delete();
+		assertThat(oxCard.isDeleted()).isTrue();
+	}
+
+	@Test
+	@DisplayName("rollback 메서드시 isDeleted는 false -> true 가 되야함")
+	void shouldFalseWhenCallRollback() {
+		OxCard oxCard = OxCard.builder()
+			.cardId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.categoryId(Id.generateNextId())
+			.images(List.of(new Image("image1"), new Image("image2")))
+			.title(new Title("title"))
+			.oxAnswer(OxAnswer.O)
+			.isDeleted(true)
+			.build();
+		oxCard.rollback();
+		assertThat(oxCard.isDeleted()).isFalse();
+	}
+}

--- a/src/test/java/com/almondia/meca/card/domain/entity/KeywordCardTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/entity/KeywordCardTest.java
@@ -1,0 +1,37 @@
+package com.almondia.meca.card.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.metamodel.EntityType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.almondia.meca.common.configuration.jpa.JpaAuditingConfiguration;
+
+/**
+ * 데이터 속성 생성 테스트
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfiguration.class})
+class KeywordCardTest {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("데이터 속성 생성 테스트")
+	void oxCardAttributeCreationTest() {
+		EntityType<?> entityType = entityManager.getMetamodel().entity(KeywordCard.class);
+		assertThat(entityType).isNotNull();
+		assertThat(entityType.getName()).isEqualTo("KeywordCard");
+		assertThat(entityType.getAttributes()).extracting("name")
+			.containsExactlyInAnyOrder("question", "isDeleted", "cardId", "categoryId", "title", "images", "createdAt",
+				"modifiedAt", "keywordAnswer");
+	}
+}

--- a/src/test/java/com/almondia/meca/card/domain/entity/MultiChoiceCardTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/entity/MultiChoiceCardTest.java
@@ -1,0 +1,39 @@
+package com.almondia.meca.card.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.metamodel.EntityType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.almondia.meca.common.configuration.jpa.JpaAuditingConfiguration;
+
+/**
+ * 1. 데이터 속성 생성 테스트
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfiguration.class})
+class MultiChoiceCardTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("데이터 속성 생성 테스트")
+	void oxCardAttributeCreationTest() {
+		EntityType<?> entityType = entityManager.getMetamodel().entity(MultiChoiceCard.class);
+		assertThat(entityType).isNotNull();
+		assertThat(entityType.getName()).isEqualTo("MultiChoiceCard");
+		assertThat(entityType.getAttributes()).extracting("name")
+			.containsExactlyInAnyOrder("question", "isDeleted", "cardId", "categoryId", "title", "images", "createdAt",
+				"modifiedAt", "multiChoiceAnswer");
+	}
+
+}

--- a/src/test/java/com/almondia/meca/card/domain/entity/OxCardTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/entity/OxCardTest.java
@@ -1,0 +1,34 @@
+package com.almondia.meca.card.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.metamodel.EntityType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+/**
+ * 1. 데이터 속성 생성 테스트
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class OxCardTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("데이터 속성 생성 테스트")
+	void oxCardAttributeCreationTest() {
+		EntityType<?> entityType = entityManager.getMetamodel().entity(OxCard.class);
+		assertThat(entityType).isNotNull();
+		assertThat(entityType.getName()).isEqualTo("OxCard");
+		assertThat(entityType.getAttributes()).extracting("name")
+			.containsExactlyInAnyOrder("question", "isDeleted", "cardId", "categoryId", "title", "images", "createdAt",
+				"modifiedAt", "oxAnswer");
+	}
+}

--- a/src/test/java/com/almondia/meca/card/domain/vo/ImageTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/vo/ImageTest.java
@@ -1,0 +1,18 @@
+package com.almondia.meca.card.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 255길이 초과한 링크를 넣을 수 없습니다
+ */
+class ImageTest {
+
+	@Test
+	@DisplayName("255길이 초과한 링크를 넣을 수 없습니다")
+	void validateLengthTest() {
+		assertThatThrownBy(() -> new Image("a".repeat(256))).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/com/almondia/meca/card/domain/vo/KeywordAnswerTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/vo/KeywordAnswerTest.java
@@ -1,0 +1,18 @@
+package com.almondia.meca.card.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 1. keyword는 500 길이 이상 입력할 수 없습니다
+ */
+class KeywordAnswerTest {
+
+	@Test
+	@DisplayName("keyword는 500 길이 이상 입력할 수 없습니다")
+	void validationTest() {
+		assertThatThrownBy(() -> new KeywordAnswer("a".repeat(501))).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/com/almondia/meca/card/domain/vo/MultiChoiceAnswerTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/vo/MultiChoiceAnswerTest.java
@@ -1,0 +1,23 @@
+package com.almondia.meca.card.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * 1. 객관식 정답은 1~5의 숫자 이외의 입력을 받을 수 없습니다
+ *
+ */
+class MultiChoiceAnswerTest {
+
+	@ParameterizedTest
+	@DisplayName("객관식 정답은 1~5의 숫자 이외의 입력을 받을 수 없습니다")
+	@CsvSource({
+		"0", "6"
+	})
+	void validateTest(int number) {
+		assertThatThrownBy(() -> new MultiChoiceAnswer(number)).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/com/almondia/meca/card/domain/vo/QuestionTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/vo/QuestionTest.java
@@ -1,0 +1,27 @@
+package com.almondia.meca.card.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 1. 문제를 공배으로 비워 둘 수 없습니다
+ * 2. 500자 이상 입력할 수 없습니다
+ */
+class QuestionTest {
+
+	@Test
+	@DisplayName("문제를 공배으로 비워 둘 수 없습니다")
+	void notEmptyQuestion() {
+		String input = " ";
+		assertThatThrownBy(() -> new Question(input)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("500자 이상 입력할 수 없습니다")
+	void shouldThrowMoreThan500() {
+		String input = "a".repeat(501);
+		assertThatThrownBy(() -> new Question(input)).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/com/almondia/meca/card/domain/vo/TitleTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/vo/TitleTest.java
@@ -1,0 +1,30 @@
+package com.almondia.meca.card.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * 1. 2이상 20 이하의 글자를 입력 가능하다
+ * 2. 공백만 입력할 수 없다
+ */
+class TitleTest {
+
+	@ParameterizedTest
+	@DisplayName("2이상 20 이하의 글자를 입력 가능하다")
+	@CsvSource({
+		"a", "aaaaaaaaaaaaaaaaaaaaa"
+	})
+	void titleLengthTest(String input) {
+		assertThatThrownBy(() -> new Title(input)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("공백만 입력할 수 없다")
+	void test() {
+		assertThatThrownBy(() -> new Title(" ".repeat(2))).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/com/almondia/meca/card/sevice/CardServiceTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/CardServiceTest.java
@@ -1,0 +1,84 @@
+package com.almondia.meca.card.sevice;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
+import com.almondia.meca.card.domain.entity.KeywordCard;
+import com.almondia.meca.card.domain.entity.MultiChoiceCard;
+import com.almondia.meca.card.domain.entity.OxCard;
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.KeywordAnswer;
+import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
+import com.almondia.meca.card.domain.vo.OxAnswer;
+import com.almondia.meca.card.domain.vo.Question;
+import com.almondia.meca.card.domain.vo.Title;
+import com.almondia.meca.card.repository.KeywordCardRepository;
+import com.almondia.meca.card.repository.MultiChoiceCardRepository;
+import com.almondia.meca.card.repository.OxCardRepository;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 1. oxCard type정보가 들어가면 oxCard 정보가 저장되는지 검증
+ * 2. keywordCard type 정보가 들어가면 keywordCard 정보가 저장되는지 검증
+ * 3. multi choice card type 정보가 들어가면 MultiChoiceCard 정보가 저장되는 지 검증
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(CardService.class)
+class CardServiceTest {
+
+	@Autowired
+	CardService cardService;
+
+	@Autowired
+	OxCardRepository oxCardRepository;
+
+	@Autowired
+	KeywordCardRepository keywordCardRepository;
+
+	@Autowired
+	MultiChoiceCardRepository multiChoiceCardRepository;
+
+	@Test
+	@DisplayName("oxCard type정보가 들어가면 oxCard 정보가 저장되는지 검증")
+	void shouldSaveOxCardTest() {
+		cardService.saveCard(makeSaveCardRequest().oxAnswer(OxAnswer.O).cardType(CardType.OX_QUIZ).build());
+		List<OxCard> all = oxCardRepository.findAll();
+		assertThat(all).isNotEmpty();
+	}
+
+	@Test
+	@DisplayName("keywordCard type 정보가 들어가면 keywordCard 정보가 저장되는지 검증")
+	void shouldSaveKeywordCardTest() {
+		cardService.saveCard(makeSaveCardRequest().keywordAnswer(new KeywordAnswer("asdf"))
+			.cardType(CardType.KEYWORD).build());
+		List<KeywordCard> all = keywordCardRepository.findAll();
+		assertThat(all).isNotEmpty();
+	}
+
+	@Test
+	@DisplayName("multi choice card type 정보가 들어가면 MultiChoiceCard 정보가 저장되는 지 검증")
+	void shouldSaveMultiCardTest() {
+		cardService.saveCard(
+			makeSaveCardRequest().multiChoiceAnswer(new MultiChoiceAnswer(1)).cardType(CardType.MULTI_CHOICE).build());
+		List<MultiChoiceCard> all = multiChoiceCardRepository.findAll();
+		assertThat(all).isNotEmpty();
+	}
+
+	private SaveCardRequestDto.SaveCardRequestDtoBuilder makeSaveCardRequest() {
+		return SaveCardRequestDto.builder()
+			.title(new Title("title"))
+			.question(new Question("question"))
+			.categoryId(Id.generateNextId())
+			.images("A,B,C");
+	}
+}

--- a/src/test/java/com/almondia/meca/card/sevice/helper/CardFactoryTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/helper/CardFactoryTest.java
@@ -1,0 +1,86 @@
+package com.almondia.meca.card.sevice.helper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
+import com.almondia.meca.card.domain.entity.Card;
+import com.almondia.meca.card.domain.entity.KeywordCard;
+import com.almondia.meca.card.domain.entity.MultiChoiceCard;
+import com.almondia.meca.card.domain.entity.OxCard;
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.KeywordAnswer;
+import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
+import com.almondia.meca.card.domain.vo.OxAnswer;
+import com.almondia.meca.card.domain.vo.Question;
+import com.almondia.meca.card.domain.vo.Title;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 1. OxCard 속성별 인스턴스를 잘 생성했는지 검증
+ * 2. KeywordCard 속성별 인스턴스를 잘 생성했는지 검증
+ * 3. MultiChoiceCard 속성별 인스턴스 잘 생성했는지 검증
+ */
+class CardFactoryTest {
+
+	@Test
+	@DisplayName("OxCard 속성별 인스턴스를 잘 생성했는지 검증")
+	public void newInstanceOxCardTest() {
+		Card card = CardFactory.genCard(makeSaveCardRequest()
+			.oxAnswer(OxAnswer.O)
+			.cardType(CardType.OX_QUIZ)
+			.build());
+		assertThat(card).isInstanceOf(OxCard.class);
+		assertThat(card).hasFieldOrProperty("title")
+			.hasFieldOrProperty("question")
+			.hasFieldOrProperty("categoryId")
+			.hasFieldOrProperty("images")
+			.hasFieldOrProperty("cardType")
+			.hasFieldOrProperty("cardId")
+			.hasFieldOrProperty("oxAnswer");
+	}
+
+	@Test
+	@DisplayName("KeywordCard 속성별 인스턴스를 잘 생성했는지 검증")
+	public void newInstanceKeywordCardTest() {
+		Card card = CardFactory.genCard(makeSaveCardRequest()
+			.keywordAnswer(new KeywordAnswer("개발자"))
+			.cardType(CardType.KEYWORD)
+			.build());
+		assertThat(card).isInstanceOf(KeywordCard.class);
+		assertThat(card).hasFieldOrProperty("title")
+			.hasFieldOrProperty("question")
+			.hasFieldOrProperty("categoryId")
+			.hasFieldOrProperty("images")
+			.hasFieldOrProperty("cardType")
+			.hasFieldOrProperty("cardId")
+			.hasFieldOrProperty("keywordAnswer");
+	}
+
+	@Test
+	@DisplayName("MultiChoiceCard 속성별 인스턴스를 잘 생성했는지 검증")
+	public void newInstanceMultiChoiceCardTest() {
+		Card card = CardFactory.genCard(makeSaveCardRequest()
+			.multiChoiceAnswer(new MultiChoiceAnswer(1))
+			.cardType(CardType.MULTI_CHOICE)
+			.build());
+		assertThat(card).isInstanceOf(MultiChoiceCard.class);
+		assertThat(card).hasFieldOrProperty("title")
+			.hasFieldOrProperty("question")
+			.hasFieldOrProperty("categoryId")
+			.hasFieldOrProperty("images")
+			.hasFieldOrProperty("cardType")
+			.hasFieldOrProperty("cardId")
+			.hasFieldOrProperty("multiChoiceAnswer");
+	}
+
+	private SaveCardRequestDto.SaveCardRequestDtoBuilder makeSaveCardRequest() {
+		return SaveCardRequestDto.builder()
+			.title(new Title("title"))
+			.question(new Question("question"))
+			.categoryId(Id.generateNextId())
+			.images("A,B,C");
+	}
+}

--- a/src/test/java/com/almondia/meca/card/sevice/helper/CardMapperTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/helper/CardMapperTest.java
@@ -1,0 +1,120 @@
+package com.almondia.meca.card.sevice.helper;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.almondia.meca.card.controller.dto.CardResponseDto;
+import com.almondia.meca.card.domain.entity.KeywordCard;
+import com.almondia.meca.card.domain.entity.MultiChoiceCard;
+import com.almondia.meca.card.domain.entity.OxCard;
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.Image;
+import com.almondia.meca.card.domain.vo.KeywordAnswer;
+import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
+import com.almondia.meca.card.domain.vo.OxAnswer;
+import com.almondia.meca.card.domain.vo.Question;
+import com.almondia.meca.card.domain.vo.Title;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 카드별 속성 변환이 잘 일어나는지 검증
+ */
+class CardMapperTest {
+
+	@Test
+	void mapperOxCardTest() {
+		CardResponseDto dto = CardMapper.oxCardToDto(makeOxCard());
+		assertThat(dto)
+			.hasFieldOrProperty("cardId")
+			.hasFieldOrProperty("title")
+			.hasFieldOrProperty("question")
+			.hasFieldOrProperty("categoryId")
+			.hasFieldOrProperty("images")
+			.hasFieldOrProperty("cardType")
+			.hasFieldOrProperty("isDeleted")
+			.hasFieldOrProperty("createdAt")
+			.hasFieldOrProperty("modifiedAt")
+			.hasFieldOrProperty("oxAnswer");
+	}
+
+	@Test
+	void mapperKeywordCardTest() {
+		CardResponseDto dto = CardMapper.keywordCardToDto(makeKeywordCard());
+		assertThat(dto)
+			.hasFieldOrProperty("cardId")
+			.hasFieldOrProperty("title")
+			.hasFieldOrProperty("question")
+			.hasFieldOrProperty("categoryId")
+			.hasFieldOrProperty("images")
+			.hasFieldOrProperty("cardType")
+			.hasFieldOrProperty("isDeleted")
+			.hasFieldOrProperty("createdAt")
+			.hasFieldOrProperty("modifiedAt")
+			.hasFieldOrProperty("keywordAnswer");
+	}
+
+	@Test
+	void mapperMultiChoiceCardTest() {
+		CardResponseDto dto = CardMapper.multiChoiceCardToDto(multiChoiceCard());
+		assertThat(dto)
+			.hasFieldOrProperty("cardId")
+			.hasFieldOrProperty("title")
+			.hasFieldOrProperty("question")
+			.hasFieldOrProperty("categoryId")
+			.hasFieldOrProperty("images")
+			.hasFieldOrProperty("cardType")
+			.hasFieldOrProperty("isDeleted")
+			.hasFieldOrProperty("createdAt")
+			.hasFieldOrProperty("modifiedAt")
+			.hasFieldOrProperty("multiChoiceAnswer");
+	}
+
+	private OxCard makeOxCard() {
+		return OxCard.builder()
+			.cardId(Id.generateNextId())
+			.title(new Title("title"))
+			.question(new Question("question"))
+			.images(List.of(new Image("A"), new Image("B"), new Image("C")))
+			.categoryId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.isDeleted(false)
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.oxAnswer(OxAnswer.O)
+			.build();
+	}
+
+	private KeywordCard makeKeywordCard() {
+		return KeywordCard.builder()
+			.cardId(Id.generateNextId())
+			.title(new Title("title"))
+			.question(new Question("question"))
+			.images(List.of(new Image("A"), new Image("B"), new Image("C")))
+			.categoryId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.isDeleted(false)
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.keywordAnswer(new KeywordAnswer("keyword"))
+			.build();
+	}
+
+	private MultiChoiceCard multiChoiceCard() {
+		return MultiChoiceCard.builder()
+			.cardId(Id.generateNextId())
+			.title(new Title("title"))
+			.question(new Question("question"))
+			.images(List.of(new Image("A"), new Image("B"), new Image("C")))
+			.categoryId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.isDeleted(false)
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.multiChoiceAnswer(new MultiChoiceAnswer(1))
+			.build();
+	}
+}


### PR DESCRIPTION
## 요약
- 카드 도메인 추가 
    - 카드 엔티티를 객관식, OX, 키워드 3개의 카드로 분리했고 DB에서는 싱글 테이블로 관리한다
- 카드 등록 API 구현 완료


## 추가 구현해야 될 사항
- 카테고리가 본인 카테고리인지 검증이 필요함. 
    -  카테고리 도메인과 카테고리 등록 및 조회 구현 후 이 부분 로직을 추가해야함 