### PR TITLE
feat/#22: 카테고리 추가 API 구현

### DIFF
--- a/src/main/java/com/almondia/meca/category/controller/CategoryController.java
+++ b/src/main/java/com/almondia/meca/category/controller/CategoryController.java
@@ -1,0 +1,36 @@
+package com.almondia.meca.category.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.almondia.meca.category.controller.dto.CategoryResponseDto;
+import com.almondia.meca.category.controller.dto.SaveCategoryRequestDto;
+import com.almondia.meca.category.service.CategoryService;
+import com.almondia.meca.member.domain.entity.Member;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+	private final CategoryService categoryService;
+
+	@PostMapping
+	@Secured("ROLE_USER")
+	public ResponseEntity<CategoryResponseDto> CategoryEntity(
+		@AuthenticationPrincipal Member member,
+		@RequestBody SaveCategoryRequestDto saveCategoryRequestDto
+	) {
+		CategoryResponseDto categoryResponseDto = categoryService.saveCategory(saveCategoryRequestDto,
+			member.getMemberId());
+		return ResponseEntity.status(HttpStatus.CREATED).body(categoryResponseDto);
+	}
+}

--- a/src/main/java/com/almondia/meca/category/controller/dto/CategoryResponseDto.java
+++ b/src/main/java/com/almondia/meca/category/controller/dto/CategoryResponseDto.java
@@ -1,0 +1,22 @@
+package com.almondia.meca.category.controller.dto;
+
+import java.time.LocalDateTime;
+
+import com.almondia.meca.category.domain.vo.Title;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Builder
+@AllArgsConstructor
+public class CategoryResponseDto {
+
+	private final Id categoryId;
+	private final Id memberId;
+	private final Title title;
+	private final boolean isDeleted;
+	private final boolean isShared;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/almondia/meca/category/controller/dto/CategoryResponseDto.java
+++ b/src/main/java/com/almondia/meca/category/controller/dto/CategoryResponseDto.java
@@ -7,9 +7,11 @@ import com.almondia.meca.common.domain.vo.Id;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
 @AllArgsConstructor
+@Getter
 public class CategoryResponseDto {
 
 	private final Id categoryId;

--- a/src/main/java/com/almondia/meca/category/controller/dto/SaveCategoryRequestDto.java
+++ b/src/main/java/com/almondia/meca/category/controller/dto/SaveCategoryRequestDto.java
@@ -1,0 +1,18 @@
+package com.almondia.meca.category.controller.dto;
+
+import com.almondia.meca.category.domain.vo.Title;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SaveCategoryRequestDto {
+
+	private Title title;
+}

--- a/src/main/java/com/almondia/meca/category/domain/entity/Category.java
+++ b/src/main/java/com/almondia/meca/category/domain/entity/Category.java
@@ -29,6 +29,10 @@ public class Category extends DateEntity {
 	@AttributeOverride(name = "title", column = @Column(name = "title", nullable = false, length = 60))
 	private Title title;
 
+	@Embedded
+	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, columnDefinition = "BINARY(16)"))
+	private Id memberId;
+
 	private boolean isDeleted;
 
 	private boolean isShared;

--- a/src/main/java/com/almondia/meca/category/repository/CategoryRepository.java
+++ b/src/main/java/com/almondia/meca/category/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package com.almondia.meca.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.common.domain.vo.Id;
+
+public interface CategoryRepository extends JpaRepository<Category, Id> {
+}

--- a/src/main/java/com/almondia/meca/category/service/CategoryService.java
+++ b/src/main/java/com/almondia/meca/category/service/CategoryService.java
@@ -1,0 +1,28 @@
+package com.almondia.meca.category.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.almondia.meca.category.controller.dto.CategoryResponseDto;
+import com.almondia.meca.category.controller.dto.SaveCategoryRequestDto;
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.category.repository.CategoryRepository;
+import com.almondia.meca.category.service.helper.CategoryFactory;
+import com.almondia.meca.category.service.helper.CategoryMapper;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+	private final CategoryRepository categoryRepository;
+
+	@Transactional
+	public CategoryResponseDto saveCategory(SaveCategoryRequestDto saveCategoryRequestDto, Id memberId) {
+		Category category = CategoryFactory.genCategory(saveCategoryRequestDto, memberId);
+		Category result = categoryRepository.save(category);
+		return CategoryMapper.entityToCategoryResponseDto(result);
+	}
+}

--- a/src/main/java/com/almondia/meca/category/service/helper/CategoryFactory.java
+++ b/src/main/java/com/almondia/meca/category/service/helper/CategoryFactory.java
@@ -1,0 +1,16 @@
+package com.almondia.meca.category.service.helper;
+
+import com.almondia.meca.category.controller.dto.SaveCategoryRequestDto;
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.common.domain.vo.Id;
+
+public class CategoryFactory {
+
+	public static Category genCategory(SaveCategoryRequestDto saveCategoryRequestDto, Id memberId) {
+		return Category.builder()
+			.categoryId(Id.generateNextId())
+			.memberId(memberId)
+			.title(saveCategoryRequestDto.getTitle())
+			.build();
+	}
+}

--- a/src/main/java/com/almondia/meca/category/service/helper/CategoryMapper.java
+++ b/src/main/java/com/almondia/meca/category/service/helper/CategoryMapper.java
@@ -1,0 +1,19 @@
+package com.almondia.meca.category.service.helper;
+
+import com.almondia.meca.category.controller.dto.CategoryResponseDto;
+import com.almondia.meca.category.domain.entity.Category;
+
+public class CategoryMapper {
+
+	public static CategoryResponseDto entityToCategoryResponseDto(Category category) {
+		return CategoryResponseDto.builder()
+			.categoryId(category.getCategoryId())
+			.memberId(category.getMemberId())
+			.title(category.getTitle())
+			.isDeleted(category.isDeleted())
+			.isShared(category.isShared())
+			.createdAt(category.getCreatedAt())
+			.modifiedAt(category.getModifiedAt())
+			.build();
+	}
+}

--- a/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
@@ -1,0 +1,78 @@
+package com.almondia.meca.category.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.almondia.meca.category.controller.dto.CategoryResponseDto;
+import com.almondia.meca.category.controller.dto.SaveCategoryRequestDto;
+import com.almondia.meca.category.domain.vo.Title;
+import com.almondia.meca.category.service.CategoryService;
+import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
+import com.almondia.meca.common.configuration.security.filter.JwtAuthenticationFilter;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.mock.security.WithMockMember;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(CategoryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({JacksonConfiguration.class})
+class CategoryControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	CategoryService categoryservice;
+
+	@MockBean
+	JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Test
+	@WithMockMember
+	void test() throws Exception {
+		Mockito.doReturn(CategoryResponseDto
+			.builder()
+			.categoryId(Id.generateNextId())
+			.memberId(Id.generateNextId())
+			.title(new Title("title"))
+			.isDeleted(false)
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.build()).when(categoryservice).saveCategory(any(), any());
+		mockMvc.perform(post("/api/v1/categories")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding(StandardCharsets.UTF_8)
+				.content(makeCategoryRequestDto()))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("category_id").exists())
+			.andExpect(jsonPath("member_id").exists())
+			.andExpect(jsonPath("title").exists())
+			.andExpect(jsonPath("deleted").exists())
+			.andExpect(jsonPath("shared").exists())
+			.andExpect(jsonPath("created_at").exists())
+			.andExpect(jsonPath("modified_at").exists());
+	}
+
+	private String makeCategoryRequestDto() throws JsonProcessingException {
+		SaveCategoryRequestDto requestDto = SaveCategoryRequestDto.builder().title(new Title("title")).build();
+		return objectMapper.writeValueAsString(requestDto);
+	}
+}

--- a/src/test/java/com/almondia/meca/category/domain/entity/CategoryTest.java
+++ b/src/test/java/com/almondia/meca/category/domain/entity/CategoryTest.java
@@ -43,7 +43,8 @@ class CategoryTest {
 		assertThat(entityType).isNotNull();
 		assertThat(entityType.getName()).isEqualTo("Category");
 		assertThat(entityType.getAttributes()).extracting("name")
-			.containsExactlyInAnyOrder("categoryId", "title", "isDeleted", "isShared", "createdAt", "modifiedAt");
+			.containsExactlyInAnyOrder("memberId", "categoryId", "title", "isDeleted", "isShared", "createdAt",
+				"modifiedAt");
 	}
 
 	@Test
@@ -52,6 +53,7 @@ class CategoryTest {
 		JpaRepository<Category, Id> categoryRepository = new SimpleJpaRepository<>(Category.class, entityManager);
 		Category category = Category.builder()
 			.categoryId(Id.generateNextId())
+			.memberId(Id.generateNextId())
 			.title(new Title("title"))
 			.build();
 		categoryRepository.saveAndFlush(category);
@@ -67,6 +69,7 @@ class CategoryTest {
 		JpaRepository<Category, Id> categoryRepository = new SimpleJpaRepository<>(Category.class, entityManager);
 		Category category = Category.builder()
 			.categoryId(Id.generateNextId())
+			.memberId(Id.generateNextId())
 			.title(new Title("title"))
 			.build();
 		Category temp = categoryRepository.save(category);

--- a/src/test/java/com/almondia/meca/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/almondia/meca/category/service/CategoryServiceTest.java
@@ -1,0 +1,43 @@
+package com.almondia.meca.category.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.almondia.meca.category.controller.dto.SaveCategoryRequestDto;
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.category.domain.vo.Title;
+import com.almondia.meca.category.repository.CategoryRepository;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 카테고리 등록시 영속성 및 응답 테스트
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({CategoryService.class})
+class CategoryServiceTest {
+
+	@Autowired
+	CategoryService categoryService;
+
+	@Autowired
+	CategoryRepository categoryRepository;
+
+	@Test
+	@DisplayName("카테고리 등록시 영속성 및 응답 테스트")
+	void test() {
+		categoryService.saveCategory(SaveCategoryRequestDto.builder().title(new Title("title")).build(),
+			Id.generateNextId());
+
+		List<Category> all = categoryRepository.findAll();
+		assertThat(all).isNotEmpty();
+	}
+}

--- a/src/test/java/com/almondia/meca/category/service/helper/CategoryFactoryTest.java
+++ b/src/test/java/com/almondia/meca/category/service/helper/CategoryFactoryTest.java
@@ -1,0 +1,33 @@
+package com.almondia.meca.category.service.helper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.almondia.meca.category.controller.dto.SaveCategoryRequestDto;
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.category.domain.vo.Title;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 1. 요청 속성에 맞게 인스턴스를 잘 생성했는 지 검증
+ */
+class CategoryFactoryTest {
+
+	@Test
+	@DisplayName("요청 속성에 맞게 인스턴스를 잘 생성했는 지 검증")
+	void createEntityFromSaveCategoryRequestDtoTest() {
+		SaveCategoryRequestDto saveCategoryRequestDto = SaveCategoryRequestDto.builder()
+			.title(new Title("title"))
+			.build();
+		Id memberId = Id.generateNextId();
+		Category category = CategoryFactory.genCategory(saveCategoryRequestDto, memberId);
+		assertThat(category)
+			.hasFieldOrProperty("categoryId")
+			.hasFieldOrPropertyWithValue("title", saveCategoryRequestDto.getTitle())
+			.hasFieldOrPropertyWithValue("memberId", memberId)
+			.hasFieldOrProperty("isDeleted")
+			.hasFieldOrProperty("isShared");
+	}
+}

--- a/src/test/java/com/almondia/meca/category/service/helper/CategoryMapperTest.java
+++ b/src/test/java/com/almondia/meca/category/service/helper/CategoryMapperTest.java
@@ -1,0 +1,43 @@
+package com.almondia.meca.category.service.helper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.almondia.meca.category.controller.dto.CategoryResponseDto;
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.category.domain.vo.Title;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 1. 성공적으로 응답 포맷으로 변환해야 함
+ */
+class CategoryMapperTest {
+
+	@Test
+	@DisplayName("성공적으로 응답 포맷으로 변환해야 함")
+	void shouldReturnResponseFormatWhenCallToCategoryResponseDtoTest() {
+		CategoryResponseDto dto = CategoryMapper.entityToCategoryResponseDto(makeCategory());
+		assertThat(dto)
+			.hasFieldOrProperty("categoryId")
+			.hasFieldOrProperty("memberId")
+			.hasFieldOrProperty("title")
+			.hasFieldOrProperty("isDeleted")
+			.hasFieldOrProperty("isShared")
+			.hasFieldOrProperty("createdAt")
+			.hasFieldOrProperty("modifiedAt");
+	}
+
+	private Category makeCategory() {
+		return Category.builder()
+			.memberId(Id.generateNextId())
+			.categoryId(Id.generateNextId())
+			.title(new Title("title"))
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.build();
+	}
+}

--- a/src/test/java/com/almondia/meca/mock/security/WithMockMember.java
+++ b/src/test/java/com/almondia/meca/mock/security/WithMockMember.java
@@ -1,0 +1,31 @@
+package com.almondia.meca.mock.security;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import com.almondia.meca.member.domain.vo.OAuthType;
+import com.almondia.meca.member.domain.vo.Role;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@WithSecurityContext(factory = WithMockMemberSecurityContextFactory.class)
+public @interface WithMockMember {
+
+	String id() default "2825b9a9-d89a-4301-99b5-a7668a5b5fff";
+
+	String email() default "helloworld@naver.com";
+
+	String name() default "hello";
+
+	OAuthType oAuthType() default OAuthType.GOOGLE;
+
+	Role role() default Role.USER;
+}

--- a/src/test/java/com/almondia/meca/mock/security/WithMockMemberSecurityContextFactory.java
+++ b/src/test/java/com/almondia/meca/mock/security/WithMockMemberSecurityContextFactory.java
@@ -1,0 +1,39 @@
+package com.almondia.meca.mock.security;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.entity.Member;
+import com.almondia.meca.member.domain.vo.Email;
+import com.almondia.meca.member.domain.vo.Name;
+
+public class WithMockMemberSecurityContextFactory implements WithSecurityContextFactory<WithMockMember> {
+
+	@Override
+	public SecurityContext createSecurityContext(WithMockMember annotation) {
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		Member member = Member.builder()
+			.name(new Name(annotation.name()))
+			.email(new Email(annotation.email()))
+			.memberId(new Id(annotation.id()))
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.oAuthType(annotation.oAuthType())
+			.role(annotation.role())
+			.build();
+		Collection<? extends GrantedAuthority> authorities = Collections.singletonList(
+			new SimpleGrantedAuthority(member.getRole().getDetails())
+		);
+		context.setAuthentication(new UsernamePasswordAuthenticationToken(member, "", authorities));
+		return context;
+	}
+}


### PR DESCRIPTION
## 요약
- title을 입력 받을 시 카테고리 API 추가 로직 구현
- [POST] /api/v1/cards
- 생성 성공시 응답은 201이며 카드 정보를 반환함

입력
![image](https://user-images.githubusercontent.com/39326175/223917254-be6366b8-1496-4dc2-8a0f-a5e630d2a34b.png)

출력
![image](https://user-images.githubusercontent.com/39326175/223917276-14fd96d7-375c-4ba8-a210-ca60abea36d2.png)
