### PR TITLE
feat/#22: 카테고리 수정 API 구현 완료

### DIFF
--- a/src/main/java/com/almondia/meca/category/controller/CategoryController.java
+++ b/src/main/java/com/almondia/meca/category/controller/CategoryController.java
@@ -5,12 +5,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.almondia.meca.category.controller.dto.CategoryResponseDto;
 import com.almondia.meca.category.controller.dto.SaveCategoryRequestDto;
+import com.almondia.meca.category.controller.dto.UpdateCategoryRequestDto;
 import com.almondia.meca.category.service.CategoryService;
 import com.almondia.meca.member.domain.entity.Member;
 
@@ -32,5 +34,16 @@ public class CategoryController {
 		CategoryResponseDto categoryResponseDto = categoryService.saveCategory(saveCategoryRequestDto,
 			member.getMemberId());
 		return ResponseEntity.status(HttpStatus.CREATED).body(categoryResponseDto);
+	}
+
+	@PutMapping
+	@Secured("ROLE_USER")
+	public ResponseEntity<CategoryResponseDto> updateCategory(
+		@AuthenticationPrincipal Member member,
+		@RequestBody UpdateCategoryRequestDto updateCategoryRequestDto
+	) {
+		CategoryResponseDto responseDto = categoryService.updateCategory(updateCategoryRequestDto,
+			member.getMemberId());
+		return ResponseEntity.ok(responseDto);
 	}
 }

--- a/src/main/java/com/almondia/meca/category/controller/dto/UpdateCategoryRequestDto.java
+++ b/src/main/java/com/almondia/meca/category/controller/dto/UpdateCategoryRequestDto.java
@@ -1,0 +1,21 @@
+package com.almondia.meca.category.controller.dto;
+
+import com.almondia.meca.category.domain.vo.Title;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UpdateCategoryRequestDto {
+
+	private Id categoryId;
+	private Title title;
+	private Boolean isShared;
+}

--- a/src/main/java/com/almondia/meca/category/domain/entity/Category.java
+++ b/src/main/java/com/almondia/meca/category/domain/entity/Category.java
@@ -48,4 +48,8 @@ public class Category extends DateEntity {
 	public void changeShare(boolean isShared) {
 		this.isShared = isShared;
 	}
+
+	public void changeTitle(Title title) {
+		this.title = title;
+	}
 }

--- a/src/main/java/com/almondia/meca/category/repository/CategoryRepository.java
+++ b/src/main/java/com/almondia/meca/category/repository/CategoryRepository.java
@@ -1,9 +1,13 @@
 package com.almondia.meca.category.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.almondia.meca.category.domain.entity.Category;
 import com.almondia.meca.common.domain.vo.Id;
 
 public interface CategoryRepository extends JpaRepository<Category, Id> {
+	Optional<Category> findByCategoryIdAndMemberId(Id categoryId, Id memberId);
+
 }

--- a/src/main/java/com/almondia/meca/category/service/CategoryService.java
+++ b/src/main/java/com/almondia/meca/category/service/CategoryService.java
@@ -5,8 +5,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.almondia.meca.category.controller.dto.CategoryResponseDto;
 import com.almondia.meca.category.controller.dto.SaveCategoryRequestDto;
+import com.almondia.meca.category.controller.dto.UpdateCategoryRequestDto;
 import com.almondia.meca.category.domain.entity.Category;
 import com.almondia.meca.category.repository.CategoryRepository;
+import com.almondia.meca.category.service.checker.CategoryChecker;
 import com.almondia.meca.category.service.helper.CategoryFactory;
 import com.almondia.meca.category.service.helper.CategoryMapper;
 import com.almondia.meca.common.domain.vo.Id;
@@ -18,11 +20,24 @@ import lombok.RequiredArgsConstructor;
 public class CategoryService {
 
 	private final CategoryRepository categoryRepository;
+	private final CategoryChecker categoryChecker;
 
 	@Transactional
 	public CategoryResponseDto saveCategory(SaveCategoryRequestDto saveCategoryRequestDto, Id memberId) {
 		Category category = CategoryFactory.genCategory(saveCategoryRequestDto, memberId);
 		Category result = categoryRepository.save(category);
 		return CategoryMapper.entityToCategoryResponseDto(result);
+	}
+
+	@Transactional
+	public CategoryResponseDto updateCategory(UpdateCategoryRequestDto updateCategoryRequestDto, Id memberId) {
+		Category category = categoryChecker.checkAuthority(updateCategoryRequestDto.getCategoryId(), memberId);
+		if (updateCategoryRequestDto.getTitle() != null) {
+			category.changeTitle(updateCategoryRequestDto.getTitle());
+		}
+		if (updateCategoryRequestDto.getIsShared() != null) {
+			category.changeShare(updateCategoryRequestDto.getIsShared());
+		}
+		return CategoryMapper.entityToCategoryResponseDto(category);
 	}
 }

--- a/src/main/java/com/almondia/meca/category/service/checker/CategoryChecker.java
+++ b/src/main/java/com/almondia/meca/category/service/checker/CategoryChecker.java
@@ -1,0 +1,23 @@
+package com.almondia.meca.category.service.checker;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.category.repository.CategoryRepository;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryChecker {
+
+	private final CategoryRepository categoryRepository;
+
+	public Category checkAuthority(Id categoryId, Id memberId) {
+		return categoryRepository.findByCategoryIdAndMemberId(categoryId, memberId)
+			.orElseThrow(
+				() -> new AccessDeniedException(String.format("%s 사용자가 권한이 없는 카테고리에 접근을 시도했습니다", memberId.toString())));
+	}
+}

--- a/src/main/java/com/almondia/meca/common/error/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/almondia/meca/common/error/GlobalControllerExceptionHandler.java
@@ -2,13 +2,17 @@ package com.almondia.meca.common.error;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.almondia.meca.auth.oauth.exception.BadWebClientRequestException;
 import com.almondia.meca.auth.oauth.exception.BadWebClientResponseException;
 
+import lombok.extern.slf4j.Slf4j;
+
 @RestControllerAdvice
+@Slf4j
 public class GlobalControllerExceptionHandler {
 
 	@ExceptionHandler(BadWebClientRequestException.class)
@@ -24,5 +28,11 @@ public class GlobalControllerExceptionHandler {
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ErrorResponseDto> handleIllegalArgumentException(IllegalArgumentException e) {
 		return ResponseEntity.badRequest().body(ErrorResponseDto.of(e));
+	}
+
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<ErrorResponseDto> handleAccessDeniedException(AccessDeniedException e) {
+		log.error(e.getMessage());
+		return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponseDto.of(e));
 	}
 }

--- a/src/main/java/com/almondia/meca/common/error/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/almondia/meca/common/error/GlobalControllerExceptionHandler.java
@@ -17,16 +17,19 @@ public class GlobalControllerExceptionHandler {
 
 	@ExceptionHandler(BadWebClientRequestException.class)
 	public ResponseEntity<ErrorResponseDto> handleBadWebClientRequestException(BadWebClientRequestException e) {
+		log.error(e.getMessage());
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponseDto.of(e));
 	}
 
 	@ExceptionHandler(BadWebClientResponseException.class)
 	public ResponseEntity<ErrorResponseDto> handleBadWebClientResponseException(BadWebClientResponseException e) {
+		log.error(e.getMessage());
 		return ResponseEntity.internalServerError().body(ErrorResponseDto.of(e));
 	}
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ErrorResponseDto> handleIllegalArgumentException(IllegalArgumentException e) {
+		log.error(e.getMessage());
 		return ResponseEntity.badRequest().body(ErrorResponseDto.of(e));
 	}
 

--- a/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
@@ -7,6 +7,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,34 +47,43 @@ class CategoryControllerTest {
 	@Autowired
 	ObjectMapper objectMapper;
 
-	@Test
-	@WithMockMember
-	void test() throws Exception {
-		Mockito.doReturn(CategoryResponseDto
-			.builder()
-			.categoryId(Id.generateNextId())
-			.memberId(Id.generateNextId())
-			.title(new Title("title"))
-			.isDeleted(false)
-			.createdAt(LocalDateTime.now())
-			.modifiedAt(LocalDateTime.now())
-			.build()).when(categoryservice).saveCategory(any(), any());
-		mockMvc.perform(post("/api/v1/categories")
-				.contentType(MediaType.APPLICATION_JSON)
-				.characterEncoding(StandardCharsets.UTF_8)
-				.content(makeCategoryRequestDto()))
-			.andExpect(status().isCreated())
-			.andExpect(jsonPath("category_id").exists())
-			.andExpect(jsonPath("member_id").exists())
-			.andExpect(jsonPath("title").exists())
-			.andExpect(jsonPath("deleted").exists())
-			.andExpect(jsonPath("shared").exists())
-			.andExpect(jsonPath("created_at").exists())
-			.andExpect(jsonPath("modified_at").exists());
+	/**
+	 * 1. 카테고리 등록시 성공하면 201 코드 및 응답 검증
+	 */
+	@Nested
+	@DisplayName("카테고리 등록")
+	class saveCategoryTest {
+		@Test
+		@DisplayName("카테고리 등록시 성공하면 201 코드 및 응답 검증")
+		@WithMockMember
+		void test() throws Exception {
+			Mockito.doReturn(CategoryResponseDto
+				.builder()
+				.categoryId(Id.generateNextId())
+				.memberId(Id.generateNextId())
+				.title(new Title("title"))
+				.isDeleted(false)
+				.createdAt(LocalDateTime.now())
+				.modifiedAt(LocalDateTime.now())
+				.build()).when(categoryservice).saveCategory(any(), any());
+			mockMvc.perform(post("/api/v1/categories")
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8)
+					.content(makeCategoryRequestDto()))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("category_id").exists())
+				.andExpect(jsonPath("member_id").exists())
+				.andExpect(jsonPath("title").exists())
+				.andExpect(jsonPath("deleted").exists())
+				.andExpect(jsonPath("shared").exists())
+				.andExpect(jsonPath("created_at").exists())
+				.andExpect(jsonPath("modified_at").exists());
+		}
+
+		private String makeCategoryRequestDto() throws JsonProcessingException {
+			SaveCategoryRequestDto requestDto = SaveCategoryRequestDto.builder().title(new Title("title")).build();
+			return objectMapper.writeValueAsString(requestDto);
+		}
 	}
 
-	private String makeCategoryRequestDto() throws JsonProcessingException {
-		SaveCategoryRequestDto requestDto = SaveCategoryRequestDto.builder().title(new Title("title")).build();
-		return objectMapper.writeValueAsString(requestDto);
-	}
 }

--- a/src/test/java/com/almondia/meca/category/domain/entity/CategoryTest.java
+++ b/src/test/java/com/almondia/meca/category/domain/entity/CategoryTest.java
@@ -27,6 +27,7 @@ import com.almondia.meca.common.domain.vo.Id;
  * 4. 삭제 메서드 호출시 삭제 상태가 된다
  * 5. 롤백 메서드 호추시 삭제 상태는 false가 된다
  * 6. 공유 변경 메서드를 통해 isShared의 상태를 변경할 수 있다
+ * 7. 타이틀 변경 요청시 해당 타이틀로 변형된다
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -116,6 +117,19 @@ class CategoryTest {
 
 		category.changeShare(true);
 		assertThat(category).hasFieldOrPropertyWithValue("isShared", true);
+	}
+
+	@Test
+	@DisplayName("타이틀 변경 요청시 해당 타이틀로 변형된다")
+	void shouldChangeTitleWhenCallChangeTitleTest() {
+		Category category = Category.builder()
+			.categoryId(Id.generateNextId())
+			.title(new Title("title"))
+			.isDeleted(true)
+			.build();
+		Title newTitle = new Title("x");
+		category.changeTitle(newTitle);
+		assertThat(category).hasFieldOrPropertyWithValue("title", newTitle);
 	}
 
 }

--- a/src/test/java/com/almondia/meca/category/service/checker/CategoryCheckerTest.java
+++ b/src/test/java/com/almondia/meca/category/service/checker/CategoryCheckerTest.java
@@ -1,0 +1,61 @@
+package com.almondia.meca.category.service.checker;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.category.domain.vo.Title;
+import com.almondia.meca.category.repository.CategoryRepository;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 1. 생성된 카테고리가 조건과 일치하면 카테고리 반환
+ * 2. 조건과 일치하는 카테고리가 없다면 권한 에러
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(CategoryChecker.class)
+class CategoryCheckerTest {
+
+	@Autowired
+	CategoryRepository categoryRepository;
+
+	@Autowired
+	CategoryChecker categoryChecker;
+
+	@Test
+	@DisplayName("생성된 카테고리가 조건과 일치하면 카테고리 반환")
+	void shouldReturnCategoryWhenMatchCategoryTest() {
+		Id categoryId = Id.generateNextId();
+		Id memberId = Id.generateNextId();
+		saveCategory(categoryId, memberId);
+		Category category = categoryChecker.checkAuthority(categoryId, memberId);
+		assertThat(category).isInstanceOf(Category.class);
+	}
+
+	@Test
+	@DisplayName("조건과 일치하는 카테고리가 없다면 권한 에러")
+	void shouldThrowWhenMisMatchCategoryTest() {
+		Id categoryId = Id.generateNextId();
+		Id memberId = Id.generateNextId();
+		saveCategory(categoryId, memberId);
+		assertThatThrownBy(() ->
+			categoryChecker.checkAuthority(Id.generateNextId(), memberId)).isInstanceOf(AccessDeniedException.class);
+	}
+
+	private void saveCategory(Id categoryId, Id memberId) {
+		categoryRepository.save(Category.builder()
+			.categoryId(categoryId)
+			.memberId(memberId)
+			.title(new Title("title"))
+			.build());
+	}
+
+}


### PR DESCRIPTION
## 요약

- 카테고리 수정은 title, share 2가지만 가능함
- body로 입력하면 null인 경우 해당 속성은 수정하지 않음
- 본인 카테고리를 수정하지 않은 경우 권한 예외 발생