### PR TITLE
feat/#29: 개인 회원 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/almondia/meca/auth/jwt/service/JwtTokenService.java
+++ b/src/main/java/com/almondia/meca/auth/jwt/service/JwtTokenService.java
@@ -11,6 +11,7 @@ import com.almondia.meca.common.configuration.jwt.JwtProperties;
 import com.almondia.meca.common.domain.vo.Id;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -52,7 +53,7 @@ public class JwtTokenService {
 		try {
 			Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token);
 			return true;
-		} catch (JwtException | IllegalArgumentException | MalformedJwtException e) {
+		} catch (JwtException | IllegalArgumentException | MalformedJwtException | ExpiredJwtException e) {
 			return false;
 		}
 	}

--- a/src/main/java/com/almondia/meca/member/controller/MemberController.java
+++ b/src/main/java/com/almondia/meca/member/controller/MemberController.java
@@ -1,0 +1,29 @@
+package com.almondia.meca.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.almondia.meca.member.controller.dto.MemberResponseDto;
+import com.almondia.meca.member.domain.entity.Member;
+import com.almondia.meca.member.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@GetMapping("/me")
+	@Secured("ROLE_USER")
+	public ResponseEntity<MemberResponseDto> getMyProfile(@AuthenticationPrincipal Member member) {
+		MemberResponseDto myProfile = memberService.findMyProfile(member.getMemberId());
+		return ResponseEntity.ok(myProfile);
+	}
+}

--- a/src/main/java/com/almondia/meca/member/controller/dto/MemberResponseDto.java
+++ b/src/main/java/com/almondia/meca/member/controller/dto/MemberResponseDto.java
@@ -1,0 +1,28 @@
+package com.almondia.meca.member.controller.dto;
+
+import java.time.LocalDateTime;
+
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.vo.Email;
+import com.almondia.meca.member.domain.vo.Name;
+import com.almondia.meca.member.domain.vo.OAuthType;
+import com.almondia.meca.member.domain.vo.Role;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@RequiredArgsConstructor
+@Getter
+public class MemberResponseDto {
+
+	private final Id memberId;
+	private final Name name;
+	private final Email email;
+	private final OAuthType oAuthType;
+	private final Role role;
+	private final boolean isDeleted;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/almondia/meca/member/service/MemberService.java
+++ b/src/main/java/com/almondia/meca/member/service/MemberService.java
@@ -1,14 +1,17 @@
 package com.almondia.meca.member.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.almondia.meca.auth.oauth.infra.attribute.OAuth2UserAttribute;
 import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.controller.dto.MemberResponseDto;
 import com.almondia.meca.member.domain.entity.Member;
 import com.almondia.meca.member.domain.vo.Email;
 import com.almondia.meca.member.domain.vo.Name;
 import com.almondia.meca.member.domain.vo.Role;
 import com.almondia.meca.member.repository.MemberRepository;
+import com.almondia.meca.member.service.helper.MemberMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,8 +33,15 @@ public class MemberService {
 		return member;
 	}
 
+	@Transactional(readOnly = true)
 	public Member findMember(Id memberId) {
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다"));
+	}
+
+	@Transactional(readOnly = true)
+	public MemberResponseDto findMyProfile(Id memberId) {
+		Member member = findMember(memberId);
+		return MemberMapper.fromEntityToDto(member);
 	}
 }

--- a/src/main/java/com/almondia/meca/member/service/helper/MemberMapper.java
+++ b/src/main/java/com/almondia/meca/member/service/helper/MemberMapper.java
@@ -1,0 +1,20 @@
+package com.almondia.meca.member.service.helper;
+
+import com.almondia.meca.member.controller.dto.MemberResponseDto;
+import com.almondia.meca.member.domain.entity.Member;
+
+public class MemberMapper {
+	
+	public static MemberResponseDto fromEntityToDto(Member member) {
+		return MemberResponseDto.builder()
+			.memberId(member.getMemberId())
+			.name(member.getName())
+			.email(member.getEmail())
+			.oAuthType(member.getOAuthType())
+			.role(member.getRole())
+			.isDeleted(member.isDeleted())
+			.createdAt(member.getCreatedAt())
+			.modifiedAt(member.getModifiedAt())
+			.build();
+	}
+}

--- a/src/test/java/com/almondia/meca/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/almondia/meca/member/controller/MemberControllerTest.java
@@ -1,0 +1,84 @@
+package com.almondia.meca.member.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
+import com.almondia.meca.common.configuration.security.filter.JwtAuthenticationFilter;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.controller.dto.MemberResponseDto;
+import com.almondia.meca.member.domain.vo.Email;
+import com.almondia.meca.member.domain.vo.Name;
+import com.almondia.meca.member.domain.vo.OAuthType;
+import com.almondia.meca.member.domain.vo.Role;
+import com.almondia.meca.member.service.MemberService;
+import com.almondia.meca.mock.security.WithMockMember;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(MemberController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({JacksonConfiguration.class})
+class MemberControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	MemberService memberService;
+
+	@MockBean
+	JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	/**
+	 * 1. 개인 프로필 조회 응답 성공시 리턴값 검증
+	 */
+	@Nested
+	@DisplayName("개인 프로필 조회")
+	class getMyProfile {
+
+		@Test
+		@DisplayName("개인 프로필 조회 응답 성공시 리턴값 검증")
+		@WithMockMember
+		void shouldReturnMemberResponseDtoAttributesWhenReturn200Test() throws Exception {
+			Mockito.doReturn(MemberResponseDto.builder()
+				.memberId(Id.generateNextId())
+				.name(new Name("name"))
+				.email(new Email("email@naver.com"))
+				.oAuthType(OAuthType.KAKAO)
+				.role(Role.USER)
+				.isDeleted(false)
+				.createdAt(LocalDateTime.now())
+				.modifiedAt(LocalDateTime.now())
+				.build()).when(memberService).findMyProfile(any());
+
+			mockMvc.perform(get("/api/v1/members/me"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("member_id").exists())
+				.andExpect(jsonPath("name").exists())
+				.andExpect(jsonPath("email").exists())
+				.andExpect(jsonPath("oauth_type").exists())
+				.andExpect(jsonPath("role").exists())
+				.andExpect(jsonPath("deleted").exists())
+				.andExpect(jsonPath("created_at").exists())
+				.andExpect(jsonPath("modified_at").exists());
+		}
+	}
+
+}

--- a/src/test/java/com/almondia/meca/member/service/MemberServiceTest.java
+++ b/src/test/java/com/almondia/meca/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.almondia.meca.member.service;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.Import;
 
 import com.almondia.meca.auth.oauth.infra.attribute.OAuth2UserAttribute;
 import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.controller.dto.MemberResponseDto;
 import com.almondia.meca.member.domain.entity.Member;
 import com.almondia.meca.member.domain.vo.Email;
 import com.almondia.meca.member.domain.vo.Name;
@@ -24,6 +26,7 @@ import com.almondia.meca.member.repository.MemberRepository;
  * 1. saveOAuthAttribute 요청시 성공적으로 회원을 db에 저장해야한다.
  * 2. findMember 요청시 없다면 IllegalArgumentException 예외 출력
  * 3. findMember 요청시 있다면 Member 반환
+ * 4. findMyProfile 요청시 findMember와 로직은 동일하지만 Dto 형태로 반환
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -71,5 +74,31 @@ class MemberServiceTest {
 			.hasFieldOrProperty("name")
 			.hasFieldOrProperty("role")
 			.hasFieldOrProperty("email");
+	}
+
+	@Test
+	@DisplayName("findMyProfile 요청시 findMember와 로직은 동일하지만 Dto 형태로 반환")
+	void shouldReturnMemberResponseDtoWHenCallFindMyProfileTest() {
+		Id id = Id.generateNextId();
+		Member member = Member.builder()
+			.memberId(id)
+			.oAuthType(OAuthType.KAKAO)
+			.name(new Name("hello"))
+			.email(new Email("hello@naver.com"))
+			.role(Role.USER)
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.build();
+		memberRepository.save(member);
+		MemberResponseDto result = memberService.findMyProfile(id);
+		assertThat(result)
+			.hasFieldOrPropertyWithValue("memberId", member.getMemberId())
+			.hasFieldOrPropertyWithValue("name", member.getName())
+			.hasFieldOrPropertyWithValue("email", member.getEmail())
+			.hasFieldOrPropertyWithValue("oAuthType", member.getOAuthType())
+			.hasFieldOrPropertyWithValue("role", member.getRole())
+			.hasFieldOrPropertyWithValue("isDeleted", member.isDeleted())
+			.hasFieldOrProperty("createdAt")
+			.hasFieldOrProperty("modifiedAt");
 	}
 }


### PR DESCRIPTION
## 요약

- URI: [GET] /api/v1/members/me로 요청하면 회원이 가지고 있는 데이터를 제공하는 API 추가