### PR TITLE
feat/#35: 카드 업데이트 API 추가

### DIFF
--- a/src/main/java/com/almondia/meca/card/controller/CardController.java
+++ b/src/main/java/com/almondia/meca/card/controller/CardController.java
@@ -4,14 +4,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.almondia.meca.card.controller.dto.CardResponseDto;
 import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
+import com.almondia.meca.card.controller.dto.UpdateCardRequestDto;
 import com.almondia.meca.card.sevice.CardService;
+import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.member.domain.entity.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -30,5 +34,16 @@ public class CardController {
 		@RequestBody SaveCardRequestDto saveCardRequestDto) {
 		CardResponseDto cardResponseDto = cardService.saveCard(saveCardRequestDto, member.getMemberId());
 		return ResponseEntity.status(HttpStatus.CREATED).body(cardResponseDto);
+	}
+
+	@Secured("ROLE_USER")
+	@PutMapping("/{cardId}")
+	public ResponseEntity<CardResponseDto> updateCard(
+		@AuthenticationPrincipal Member member,
+		@PathVariable(value = "cardId") Id cardId,
+		@RequestBody UpdateCardRequestDto updateCardRequestDto
+	) {
+		CardResponseDto responseDto = cardService.updateCard(updateCardRequestDto, cardId, member.getMemberId());
+		return ResponseEntity.ok(responseDto);
 	}
 }

--- a/src/main/java/com/almondia/meca/card/controller/CardController.java
+++ b/src/main/java/com/almondia/meca/card/controller/CardController.java
@@ -3,6 +3,7 @@ package com.almondia.meca.card.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.almondia.meca.card.controller.dto.CardResponseDto;
 import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
 import com.almondia.meca.card.sevice.CardService;
+import com.almondia.meca.member.domain.entity.Member;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,8 +25,10 @@ public class CardController {
 
 	@Secured("ROLE_USER")
 	@PostMapping
-	public ResponseEntity<CardResponseDto> saveCard(@RequestBody SaveCardRequestDto saveCardRequestDto) {
-		CardResponseDto cardResponseDto = cardService.saveCard(saveCardRequestDto);
+	public ResponseEntity<CardResponseDto> saveCard(
+		@AuthenticationPrincipal Member member,
+		@RequestBody SaveCardRequestDto saveCardRequestDto) {
+		CardResponseDto cardResponseDto = cardService.saveCard(saveCardRequestDto, member.getMemberId());
 		return ResponseEntity.status(HttpStatus.CREATED).body(cardResponseDto);
 	}
 }

--- a/src/main/java/com/almondia/meca/card/controller/dto/UpdateCardRequestDto.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/UpdateCardRequestDto.java
@@ -1,0 +1,24 @@
+package com.almondia.meca.card.controller.dto;
+
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.Question;
+import com.almondia.meca.card.domain.vo.Title;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateCardRequestDto {
+	Title title;
+	String images;
+	Question question;
+	Id categoryId;
+	CardType cardType;
+}

--- a/src/main/java/com/almondia/meca/card/domain/entity/Card.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/Card.java
@@ -49,6 +49,10 @@ public abstract class Card extends DateEntity {
 	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, columnDefinition = "BINARY(16)"))
 	Id categoryId;
 
+	@Embedded
+	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, columnDefinition = "BINARY(16)"))
+	Id memberId;
+	
 	@Column(name = "images", length = 1020)
 	@Convert(converter = ListImageConverter.class)
 	private List<Image> images;

--- a/src/main/java/com/almondia/meca/card/domain/entity/Card.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/Card.java
@@ -1,6 +1,8 @@
 package com.almondia.meca.card.domain.entity;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -52,7 +54,7 @@ public abstract class Card extends DateEntity {
 	@Embedded
 	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, columnDefinition = "BINARY(16)"))
 	Id memberId;
-	
+
 	@Column(name = "images", length = 1020)
 	@Convert(converter = ListImageConverter.class)
 	private List<Image> images;
@@ -68,5 +70,23 @@ public abstract class Card extends DateEntity {
 
 	public void rollback() {
 		isDeleted = false;
+	}
+
+	public void changeTitle(Title title) {
+		this.title = title;
+	}
+
+	public void changeImages(String images) {
+		String[] split = images.split(",");
+		this.images = Arrays.stream(split).map(Image::new)
+			.collect(Collectors.toList());
+	}
+
+	public void changeQuestion(Question question) {
+		this.question = question;
+	}
+
+	public void changeCategoryId(Id categoryId) {
+		this.categoryId = categoryId;
 	}
 }

--- a/src/main/java/com/almondia/meca/card/repository/KeywordCardRepository.java
+++ b/src/main/java/com/almondia/meca/card/repository/KeywordCardRepository.java
@@ -1,9 +1,12 @@
 package com.almondia.meca.card.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.almondia.meca.card.domain.entity.KeywordCard;
 import com.almondia.meca.common.domain.vo.Id;
 
 public interface KeywordCardRepository extends JpaRepository<KeywordCard, Id> {
+	Optional<KeywordCard> findByCardIdAndMemberId(Id cardId, Id memberId);
 }

--- a/src/main/java/com/almondia/meca/card/repository/MultiChoiceCardRepository.java
+++ b/src/main/java/com/almondia/meca/card/repository/MultiChoiceCardRepository.java
@@ -1,9 +1,13 @@
 package com.almondia.meca.card.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.almondia.meca.card.domain.entity.MultiChoiceCard;
 import com.almondia.meca.common.domain.vo.Id;
 
 public interface MultiChoiceCardRepository extends JpaRepository<MultiChoiceCard, Id> {
+	Optional<MultiChoiceCard> findByCardIdAndMemberId(Id cardId, Id memberId);
+
 }

--- a/src/main/java/com/almondia/meca/card/repository/OxCardRepository.java
+++ b/src/main/java/com/almondia/meca/card/repository/OxCardRepository.java
@@ -6,4 +6,5 @@ import com.almondia.meca.card.domain.entity.OxCard;
 import com.almondia.meca.common.domain.vo.Id;
 
 public interface OxCardRepository extends JpaRepository<OxCard, Id> {
+
 }

--- a/src/main/java/com/almondia/meca/card/repository/OxCardRepository.java
+++ b/src/main/java/com/almondia/meca/card/repository/OxCardRepository.java
@@ -1,10 +1,13 @@
 package com.almondia.meca.card.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.almondia.meca.card.domain.entity.OxCard;
 import com.almondia.meca.common.domain.vo.Id;
 
 public interface OxCardRepository extends JpaRepository<OxCard, Id> {
+	Optional<OxCard> findByCardIdAndMemberId(Id cardId, Id memberId);
 
 }

--- a/src/main/java/com/almondia/meca/card/sevice/CardService.java
+++ b/src/main/java/com/almondia/meca/card/sevice/CardService.java
@@ -13,6 +13,7 @@ import com.almondia.meca.card.repository.MultiChoiceCardRepository;
 import com.almondia.meca.card.repository.OxCardRepository;
 import com.almondia.meca.card.sevice.helper.CardFactory;
 import com.almondia.meca.card.sevice.helper.CardMapper;
+import com.almondia.meca.common.domain.vo.Id;
 
 import lombok.AllArgsConstructor;
 
@@ -24,8 +25,8 @@ public class CardService {
 	private final KeywordCardRepository keywordCardRepository;
 	private final MultiChoiceCardRepository multiChoiceCardRepository;
 
-	public CardResponseDto saveCard(SaveCardRequestDto saveCardRequestDto) {
-		Card card = CardFactory.genCard(saveCardRequestDto);
+	public CardResponseDto saveCard(SaveCardRequestDto saveCardRequestDto, Id memberId) {
+		Card card = CardFactory.genCard(saveCardRequestDto, memberId);
 		if (card instanceof OxCard) {
 			OxCard oxCard = oxCardRepository.save((OxCard)card);
 			return CardMapper.oxCardToDto(oxCard);

--- a/src/main/java/com/almondia/meca/card/sevice/CardService.java
+++ b/src/main/java/com/almondia/meca/card/sevice/CardService.java
@@ -34,17 +34,6 @@ public class CardService {
 	@Transactional
 	public CardResponseDto saveCard(SaveCardRequestDto saveCardRequestDto, Id memberId) {
 		Card card = CardFactory.genCard(saveCardRequestDto, memberId);
-		return saveCardByCardType(card);
-	}
-
-	@Transactional
-	public CardResponseDto updateCard(UpdateCardRequestDto updateCardRequestDto, Id cardId, Id memberId) {
-		categoryChecker.checkAuthority(updateCardRequestDto.getCategoryId(), memberId);
-		Card card = cardChecker.checkAuthority(cardId, memberId, updateCardRequestDto.getCardType());
-		return saveCardByCardType(card);
-	}
-
-	private CardResponseDto saveCardByCardType(Card card) {
 		if (card instanceof OxCard) {
 			OxCard oxCard = oxCardRepository.save((OxCard)card);
 			return CardMapper.oxCardToDto(oxCard);
@@ -58,5 +47,37 @@ public class CardService {
 			return CardMapper.multiChoiceCardToDto(multiChoiceCard);
 		}
 		throw new IllegalArgumentException("지원하는 카드 유형이 아닙니다");
+	}
+
+	@Transactional
+	public CardResponseDto updateCard(UpdateCardRequestDto updateCardRequestDto, Id cardId, Id memberId) {
+		Card card = cardChecker.checkAuthority(cardId, memberId, updateCardRequestDto.getCardType());
+		updateCard(updateCardRequestDto, memberId, card);
+		if (card instanceof OxCard) {
+			return CardMapper.oxCardToDto((OxCard)card);
+		}
+		if (card instanceof KeywordCard) {
+			return CardMapper.keywordCardToDto((KeywordCard)card);
+		}
+		if (card instanceof MultiChoiceCard) {
+			return CardMapper.multiChoiceCardToDto((MultiChoiceCard)card);
+		}
+		throw new IllegalArgumentException("지원하는 카드 유형이 아닙니다");
+	}
+
+	private void updateCard(UpdateCardRequestDto updateCardRequestDto, Id memberId, Card card) {
+		if (updateCardRequestDto.getTitle() != null) {
+			card.changeTitle(updateCardRequestDto.getTitle());
+		}
+		if (updateCardRequestDto.getImages() != null) {
+			card.changeImages(updateCardRequestDto.getImages());
+		}
+		if (updateCardRequestDto.getQuestion() != null) {
+			card.changeQuestion(updateCardRequestDto.getQuestion());
+		}
+		if (updateCardRequestDto.getCategoryId() != null) {
+			categoryChecker.checkAuthority(updateCardRequestDto.getCategoryId(), memberId);
+			card.changeCategoryId(updateCardRequestDto.getCategoryId());
+		}
 	}
 }

--- a/src/main/java/com/almondia/meca/card/sevice/checker/CardChecker.java
+++ b/src/main/java/com/almondia/meca/card/sevice/checker/CardChecker.java
@@ -1,0 +1,35 @@
+package com.almondia.meca.card.sevice.checker;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import com.almondia.meca.card.domain.entity.Card;
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.repository.KeywordCardRepository;
+import com.almondia.meca.card.repository.MultiChoiceCardRepository;
+import com.almondia.meca.card.repository.OxCardRepository;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CardChecker {
+
+	private final KeywordCardRepository keywordCardRepository;
+	private final OxCardRepository oxCardRepository;
+	private final MultiChoiceCardRepository multiChoiceCardRepository;
+
+	public Card checkAuthority(Id cardId, Id memberId, CardType cardType) {
+		if (cardType.equals(CardType.OX_QUIZ)) {
+			return oxCardRepository.findByCardIdAndMemberId(cardId, memberId)
+				.orElseThrow(() -> new AccessDeniedException(String.format("%s 유저는 해당 카드를 수정할 권한이 없습니다", memberId)));
+		}
+		if (cardType.equals(CardType.KEYWORD)) {
+			return keywordCardRepository.findByCardIdAndMemberId(cardId, memberId)
+				.orElseThrow(() -> new AccessDeniedException(String.format("%s 유저는 해당 카드를 수정할 권한이 없습니다", memberId)));
+		}
+		return multiChoiceCardRepository.findByCardIdAndMemberId(cardId, memberId)
+			.orElseThrow(() -> new AccessDeniedException(String.format("%s 유저는 해당 카드를 수정할 권한이 없습니다", memberId)));
+	}
+}

--- a/src/main/java/com/almondia/meca/card/sevice/helper/CardFactory.java
+++ b/src/main/java/com/almondia/meca/card/sevice/helper/CardFactory.java
@@ -17,23 +17,24 @@ public class CardFactory {
 
 	private static final String SPLIT_WORD = ",";
 
-	public static Card genCard(SaveCardRequestDto saveCardRequestDto) {
+	public static Card genCard(SaveCardRequestDto saveCardRequestDto, Id memberId) {
 		CardType cardType = saveCardRequestDto.getCardType();
 		if (cardType.equals(CardType.OX_QUIZ)) {
-			return genOxCard(saveCardRequestDto);
+			return genOxCard(saveCardRequestDto, memberId);
 		}
 		if (cardType.equals(CardType.KEYWORD)) {
-			return genKeywordCard(saveCardRequestDto);
+			return genKeywordCard(saveCardRequestDto, memberId);
 		}
 		if (cardType.equals(CardType.MULTI_CHOICE)) {
-			return genMultiChoiceCard(saveCardRequestDto);
+			return genMultiChoiceCard(saveCardRequestDto, memberId);
 		}
 		throw new IllegalArgumentException("잘못된 cardType 입니다");
 	}
 
-	private static OxCard genOxCard(SaveCardRequestDto saveCardRequestDto) {
+	private static OxCard genOxCard(SaveCardRequestDto saveCardRequestDto, Id memberId) {
 		return OxCard.builder()
 			.cardId(Id.generateNextId())
+			.memberId(memberId)
 			.question(saveCardRequestDto.getQuestion())
 			.title(saveCardRequestDto.getTitle())
 			.categoryId(saveCardRequestDto.getCategoryId())
@@ -43,9 +44,10 @@ public class CardFactory {
 			.build();
 	}
 
-	private static KeywordCard genKeywordCard(SaveCardRequestDto saveCardRequestDto) {
+	private static KeywordCard genKeywordCard(SaveCardRequestDto saveCardRequestDto, Id memberId) {
 		return KeywordCard.builder()
 			.cardId(Id.generateNextId())
+			.memberId(memberId)
 			.question(saveCardRequestDto.getQuestion())
 			.title(saveCardRequestDto.getTitle())
 			.categoryId(saveCardRequestDto.getCategoryId())
@@ -55,9 +57,10 @@ public class CardFactory {
 			.build();
 	}
 
-	private static MultiChoiceCard genMultiChoiceCard(SaveCardRequestDto saveCardRequestDto) {
+	private static MultiChoiceCard genMultiChoiceCard(SaveCardRequestDto saveCardRequestDto, Id memberId) {
 		return MultiChoiceCard.builder()
 			.cardId(Id.generateNextId())
+			.memberId(memberId)
 			.question(saveCardRequestDto.getQuestion())
 			.title(saveCardRequestDto.getTitle())
 			.categoryId(saveCardRequestDto.getCategoryId())

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -29,6 +29,7 @@ import com.almondia.meca.card.sevice.CardService;
 import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
 import com.almondia.meca.common.configuration.security.filter.JwtAuthenticationFilter;
 import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.mock.security.WithMockMember;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -52,6 +53,7 @@ class CardControllerTest {
 	ObjectMapper objectMapper;
 
 	@Test
+	@WithMockMember
 	@DisplayName("요청 성공시 201을 리턴하고 카드 정보를 반환한다")
 	void test() throws Exception {
 		SaveCardRequestDto saveCardRequestDto = SaveCardRequestDto.builder()
@@ -62,7 +64,7 @@ class CardControllerTest {
 			.cardType(CardType.OX_QUIZ)
 			.oxAnswer(OxAnswer.O)
 			.build();
-		Mockito.doReturn(makeResponse()).when(cardService).saveCard(any());
+		Mockito.doReturn(makeResponse()).when(cardService).saveCard(any(), any());
 
 		mockMvc.perform(post("/api/v1/cards")
 				.contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,9 +33,6 @@ import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.mock.security.WithMockMember;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/**
- * 1. 요청 성공시 201을 리턴하고 카드 정보를 반환한다.
- */
 @WebMvcTest(CardController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import({JacksonConfiguration.class})
@@ -52,49 +50,58 @@ class CardControllerTest {
 	@Autowired
 	ObjectMapper objectMapper;
 
-	@Test
-	@WithMockMember
-	@DisplayName("요청 성공시 201을 리턴하고 카드 정보를 반환한다")
-	void test() throws Exception {
-		SaveCardRequestDto saveCardRequestDto = SaveCardRequestDto.builder()
-			.title(new Title("title"))
-			.question(new Question("hello"))
-			.images("A,B,C,D")
-			.categoryId(Id.generateNextId())
-			.cardType(CardType.OX_QUIZ)
-			.oxAnswer(OxAnswer.O)
-			.build();
-		Mockito.doReturn(makeResponse()).when(cardService).saveCard(any(), any());
+	/**
+	 * 1. 요청 성공시 201을 리턴하고 카드 정보를 반환한다.
+	 */
+	@Nested
+	@DisplayName("카드 저장 API 테스트")
+	class saveCardTest {
 
-		mockMvc.perform(post("/api/v1/cards")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(saveCardRequestDto)))
-			.andExpect(status().isCreated())
-			.andExpect(jsonPath("card_id").exists())
-			.andExpect(jsonPath("title").exists())
-			.andExpect(jsonPath("question").exists())
-			.andExpect(jsonPath("images").exists())
-			.andExpect(jsonPath("category_id").exists())
-			.andExpect(jsonPath("deleted").exists())
-			.andExpect(jsonPath("card_type").exists())
-			.andExpect(jsonPath("created_at").exists())
-			.andExpect(jsonPath("modified_at").exists())
-			.andExpect(jsonPath("title").exists())
-			.andExpect(jsonPath("ox_answer").exists());
+		@Test
+		@WithMockMember
+		@DisplayName("요청 성공시 201을 리턴하고 카드 정보를 반환한다")
+		void test() throws Exception {
+			SaveCardRequestDto saveCardRequestDto = SaveCardRequestDto.builder()
+				.title(new Title("title"))
+				.question(new Question("hello"))
+				.images("A,B,C,D")
+				.categoryId(Id.generateNextId())
+				.cardType(CardType.OX_QUIZ)
+				.oxAnswer(OxAnswer.O)
+				.build();
+			Mockito.doReturn(makeResponse()).when(cardService).saveCard(any(), any());
+
+			mockMvc.perform(post("/api/v1/cards")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(saveCardRequestDto)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("card_id").exists())
+				.andExpect(jsonPath("title").exists())
+				.andExpect(jsonPath("question").exists())
+				.andExpect(jsonPath("images").exists())
+				.andExpect(jsonPath("category_id").exists())
+				.andExpect(jsonPath("deleted").exists())
+				.andExpect(jsonPath("card_type").exists())
+				.andExpect(jsonPath("created_at").exists())
+				.andExpect(jsonPath("modified_at").exists())
+				.andExpect(jsonPath("title").exists())
+				.andExpect(jsonPath("ox_answer").exists());
+		}
+
+		private CardResponseDto makeResponse() {
+			return CardResponseDto.builder()
+				.cardId(Id.generateNextId())
+				.title(new Title("title"))
+				.question(new Question("hello"))
+				.images(List.of(new Image("A"), new Image("B"), new Image("C")))
+				.categoryId(Id.generateNextId())
+				.cardType(CardType.OX_QUIZ)
+				.isDeleted(false)
+				.oxAnswer(OxAnswer.O)
+				.createdAt(LocalDateTime.now())
+				.modifiedAt(LocalDateTime.now())
+				.build();
+		}
 	}
 
-	private CardResponseDto makeResponse() {
-		return CardResponseDto.builder()
-			.cardId(Id.generateNextId())
-			.title(new Title("title"))
-			.question(new Question("hello"))
-			.images(List.of(new Image("A"), new Image("B"), new Image("C")))
-			.categoryId(Id.generateNextId())
-			.cardType(CardType.OX_QUIZ)
-			.isDeleted(false)
-			.oxAnswer(OxAnswer.O)
-			.createdAt(LocalDateTime.now())
-			.modifiedAt(LocalDateTime.now())
-			.build();
-	}
 }

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.almondia.meca.card.controller.dto.CardResponseDto;
 import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
+import com.almondia.meca.card.controller.dto.UpdateCardRequestDto;
 import com.almondia.meca.card.domain.vo.CardType;
 import com.almondia.meca.card.domain.vo.Image;
 import com.almondia.meca.card.domain.vo.OxAnswer;
@@ -104,4 +105,57 @@ class CardControllerTest {
 		}
 	}
 
+	/**
+	 * 1. 성공시 200 응답코드와 리턴해야할 값 검증
+	 */
+	@Nested
+	@DisplayName("카드 업데이트 API 테스트")
+	class UpdateCardTest {
+
+		@Test
+		@WithMockMember
+		@DisplayName("성공시 200 응답코드와 리턴해야할 값 검증")
+		void shouldReturn200WhenSuccessTest() throws Exception {
+			UpdateCardRequestDto requestDto = UpdateCardRequestDto.builder()
+				.title(new Title("title"))
+				.cardType(CardType.OX_QUIZ)
+				.question(new Question("question"))
+				.images("A,B,C")
+				.categoryId(Id.generateNextId())
+				.build();
+			Mockito.doReturn(makeResponse())
+				.when(cardService).updateCard(any(), any(), any());
+
+			mockMvc.perform(put("/api/v1/cards/{cardId}", Id.generateNextId().toString())
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(requestDto)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("card_id").exists())
+				.andExpect(jsonPath("title").exists())
+				.andExpect(jsonPath("question").exists())
+				.andExpect(jsonPath("images").exists())
+				.andExpect(jsonPath("category_id").exists())
+				.andExpect(jsonPath("deleted").exists())
+				.andExpect(jsonPath("card_type").exists())
+				.andExpect(jsonPath("created_at").exists())
+				.andExpect(jsonPath("modified_at").exists())
+				.andExpect(jsonPath("title").exists())
+				.andExpect(jsonPath("ox_answer").exists());
+		}
+
+		private CardResponseDto makeResponse() {
+			return CardResponseDto.builder()
+				.cardId(Id.generateNextId())
+				.title(new Title("title"))
+				.question(new Question("hello"))
+				.images(List.of(new Image("A"), new Image("B"), new Image("C")))
+				.categoryId(Id.generateNextId())
+				.cardType(CardType.OX_QUIZ)
+				.isDeleted(false)
+				.oxAnswer(OxAnswer.O)
+				.createdAt(LocalDateTime.now())
+				.modifiedAt(LocalDateTime.now())
+				.build();
+		}
+	}
 }

--- a/src/test/java/com/almondia/meca/card/domain/entity/CardTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/entity/CardTest.java
@@ -31,6 +31,10 @@ import com.almondia.meca.common.domain.vo.Id;
  * 2. entity를 생성해서 저장시 createdAt과 modifiedAt이 자동으로 업데이트되며 서로 같음
  * 3. entity 수정시 modifiedAt이 업데이트되며 modifiedAt이 createdAt보다 이후의 날짜여야 함
  * 4. delete, rollback 메서드 사용시 isDeleted 상태가 변경되어야 함
+ * 5. title 변경 메서드  정상 동작 테스트
+ * 6. images 변경 메서드 정상 동작 테스트
+ * 7. question 변경 메서드 정상 동작 테스트
+ * 8. categoryId 변경 메서드 정상 동작 테스트
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -126,5 +130,71 @@ class CardTest {
 			.build();
 		oxCard.rollback();
 		assertThat(oxCard.isDeleted()).isFalse();
+	}
+
+	@Test
+	@DisplayName("title 변경 메서드  정상 동작 테스트")
+	void shouldChangeTitleWhenCallChangeTitleTest() {
+		OxCard oxCard = OxCard.builder()
+			.cardId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.categoryId(Id.generateNextId())
+			.images(List.of(new Image("image1"), new Image("image2")))
+			.title(new Title("title"))
+			.oxAnswer(OxAnswer.O)
+			.isDeleted(true)
+			.build();
+		oxCard.changeTitle(new Title("hello"));
+		assertThat(oxCard).hasFieldOrPropertyWithValue("title", new Title("hello"));
+	}
+
+	@Test
+	@DisplayName("images 변경 메서드 정상 동작 테스트")
+	void shouldChangeImagesWhenCallChangeImagesTest() {
+		OxCard oxCard = OxCard.builder()
+			.cardId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.categoryId(Id.generateNextId())
+			.images(List.of(new Image("image1"), new Image("image2")))
+			.title(new Title("title"))
+			.oxAnswer(OxAnswer.O)
+			.isDeleted(true)
+			.build();
+		oxCard.changeImages("A,B,C,D");
+		assertThat(oxCard.getImages())
+			.contains(new Image("A"), new Image("B"), new Image("C"), new Image("D"));
+	}
+
+	@Test
+	@DisplayName("question 변경 메서드 정상 동작 테스트")
+	void shouldChangeQuestionWhenCallChangeQuestionTest() {
+		OxCard oxCard = OxCard.builder()
+			.cardId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.categoryId(Id.generateNextId())
+			.images(List.of(new Image("image1"), new Image("image2")))
+			.title(new Title("title"))
+			.oxAnswer(OxAnswer.O)
+			.isDeleted(true)
+			.build();
+		oxCard.changeQuestion(new Question("question2"));
+		assertThat(oxCard).hasFieldOrPropertyWithValue("question", new Question("question2"));
+	}
+
+	@Test
+	@DisplayName("categoryId 변경 메서드 정상 동작 테스트")
+	void shouldReturnCategoryIdWhenCallChangeCategoryIdTest() {
+		OxCard oxCard = OxCard.builder()
+			.cardId(Id.generateNextId())
+			.cardType(CardType.OX_QUIZ)
+			.categoryId(Id.generateNextId())
+			.images(List.of(new Image("image1"), new Image("image2")))
+			.title(new Title("title"))
+			.oxAnswer(OxAnswer.O)
+			.isDeleted(true)
+			.build();
+		Id categoryId = Id.generateNextId();
+		oxCard.changeCategoryId(categoryId);
+		assertThat(oxCard).hasFieldOrPropertyWithValue("categoryId", categoryId);
 	}
 }

--- a/src/test/java/com/almondia/meca/card/domain/entity/CardTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/entity/CardTest.java
@@ -47,7 +47,8 @@ class CardTest {
 		assertThat(entityType).isNotNull();
 		assertThat(entityType.getName()).isEqualTo("Card");
 		assertThat(entityType.getAttributes()).extracting("name")
-			.containsExactlyInAnyOrder("question", "isDeleted", "cardId", "categoryId", "title", "images", "createdAt",
+			.containsExactlyInAnyOrder("question", "memberId", "isDeleted", "cardId", "categoryId", "title", "images",
+				"createdAt",
 				"modifiedAt");
 	}
 
@@ -60,6 +61,7 @@ class CardTest {
 			.cardType(CardType.OX_QUIZ)
 			.question(new Question("Question"))
 			.categoryId(Id.generateNextId())
+			.memberId(Id.generateNextId())
 			.images(List.of(new Image("image1"), new Image("image2")))
 			.title(new Title("title"))
 			.oxAnswer(OxAnswer.O)
@@ -79,6 +81,7 @@ class CardTest {
 			.cardId(Id.generateNextId())
 			.cardType(CardType.OX_QUIZ)
 			.question(new Question("Question"))
+			.memberId(Id.generateNextId())
 			.categoryId(Id.generateNextId())
 			.images(List.of(new Image("image1"), new Image("image2")))
 			.title(new Title("title"))

--- a/src/test/java/com/almondia/meca/card/domain/entity/KeywordCardTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/entity/KeywordCardTest.java
@@ -32,7 +32,8 @@ class KeywordCardTest {
 		assertThat(entityType).isNotNull();
 		assertThat(entityType.getName()).isEqualTo("KeywordCard");
 		assertThat(entityType.getAttributes()).extracting("name")
-			.containsExactlyInAnyOrder("question", "isDeleted", "cardId", "categoryId", "title", "images", "createdAt",
+			.containsExactlyInAnyOrder("memberId", "question", "isDeleted", "cardId", "categoryId", "title", "images",
+				"createdAt",
 				"modifiedAt", "keywordAnswer");
 	}
 }

--- a/src/test/java/com/almondia/meca/card/domain/entity/MultiChoiceCardTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/entity/MultiChoiceCardTest.java
@@ -33,7 +33,8 @@ class MultiChoiceCardTest {
 		assertThat(entityType).isNotNull();
 		assertThat(entityType.getName()).isEqualTo("MultiChoiceCard");
 		assertThat(entityType.getAttributes()).extracting("name")
-			.containsExactlyInAnyOrder("question", "isDeleted", "cardId", "categoryId", "title", "images", "createdAt",
+			.containsExactlyInAnyOrder("memberId", "question", "isDeleted", "cardId", "categoryId", "title", "images",
+				"createdAt",
 				"modifiedAt", "multiChoiceAnswer");
 	}
 

--- a/src/test/java/com/almondia/meca/card/domain/entity/OxCardTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/entity/OxCardTest.java
@@ -32,7 +32,8 @@ class OxCardTest {
 		assertThat(entityType).isNotNull();
 		assertThat(entityType.getName()).isEqualTo("OxCard");
 		assertThat(entityType.getAttributes()).extracting("name")
-			.containsExactlyInAnyOrder("question", "isDeleted", "cardId", "categoryId", "title", "images", "createdAt",
+			.containsExactlyInAnyOrder("memberId", "question", "isDeleted", "cardId", "categoryId", "title", "images",
+				"createdAt",
 				"modifiedAt", "oxAnswer");
 	}
 }

--- a/src/test/java/com/almondia/meca/card/sevice/CardServiceTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/CardServiceTest.java
@@ -52,7 +52,8 @@ class CardServiceTest {
 	@Test
 	@DisplayName("oxCard type정보가 들어가면 oxCard 정보가 저장되는지 검증")
 	void shouldSaveOxCardTest() {
-		cardService.saveCard(makeSaveCardRequest().oxAnswer(OxAnswer.O).cardType(CardType.OX_QUIZ).build());
+		cardService.saveCard(makeSaveCardRequest().oxAnswer(OxAnswer.O).cardType(CardType.OX_QUIZ).build(),
+			Id.generateNextId());
 		List<OxCard> all = oxCardRepository.findAll();
 		assertThat(all).isNotEmpty();
 	}
@@ -60,8 +61,9 @@ class CardServiceTest {
 	@Test
 	@DisplayName("keywordCard type 정보가 들어가면 keywordCard 정보가 저장되는지 검증")
 	void shouldSaveKeywordCardTest() {
-		cardService.saveCard(makeSaveCardRequest().keywordAnswer(new KeywordAnswer("asdf"))
-			.cardType(CardType.KEYWORD).build());
+		cardService.saveCard(makeSaveCardRequest()
+			.keywordAnswer(new KeywordAnswer("asdf"))
+			.cardType(CardType.KEYWORD).build(), Id.generateNextId());
 		List<KeywordCard> all = keywordCardRepository.findAll();
 		assertThat(all).isNotEmpty();
 	}
@@ -70,7 +72,9 @@ class CardServiceTest {
 	@DisplayName("multi choice card type 정보가 들어가면 MultiChoiceCard 정보가 저장되는 지 검증")
 	void shouldSaveMultiCardTest() {
 		cardService.saveCard(
-			makeSaveCardRequest().multiChoiceAnswer(new MultiChoiceAnswer(1)).cardType(CardType.MULTI_CHOICE).build());
+			makeSaveCardRequest().multiChoiceAnswer(new MultiChoiceAnswer(1))
+				.cardType(CardType.MULTI_CHOICE).build(),
+			Id.generateNextId());
 		List<MultiChoiceCard> all = multiChoiceCardRepository.findAll();
 		assertThat(all).isNotEmpty();
 	}

--- a/src/test/java/com/almondia/meca/card/sevice/CardServiceTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/CardServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -24,17 +25,14 @@ import com.almondia.meca.card.domain.vo.Title;
 import com.almondia.meca.card.repository.KeywordCardRepository;
 import com.almondia.meca.card.repository.MultiChoiceCardRepository;
 import com.almondia.meca.card.repository.OxCardRepository;
+import com.almondia.meca.card.sevice.checker.CardChecker;
+import com.almondia.meca.category.service.checker.CategoryChecker;
 import com.almondia.meca.common.configuration.jpa.QueryDslConfiguration;
 import com.almondia.meca.common.domain.vo.Id;
 
-/**
- * 1. oxCard type정보가 들어가면 oxCard 정보가 저장되는지 검증
- * 2. keywordCard type 정보가 들어가면 keywordCard 정보가 저장되는지 검증
- * 3. multi choice card type 정보가 들어가면 MultiChoiceCard 정보가 저장되는 지 검증
- */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({CardService.class, QueryDslConfiguration.class})
+@Import({CardService.class, QueryDslConfiguration.class, CategoryChecker.class, CardChecker.class})
 class CardServiceTest {
 
 	@Autowired
@@ -49,41 +47,51 @@ class CardServiceTest {
 	@Autowired
 	MultiChoiceCardRepository multiChoiceCardRepository;
 
-	@Test
-	@DisplayName("oxCard type정보가 들어가면 oxCard 정보가 저장되는지 검증")
-	void shouldSaveOxCardTest() {
-		cardService.saveCard(makeSaveCardRequest().oxAnswer(OxAnswer.O).cardType(CardType.OX_QUIZ).build(),
-			Id.generateNextId());
-		List<OxCard> all = oxCardRepository.findAll();
-		assertThat(all).isNotEmpty();
+	/**
+	 * 1. oxCard type정보가 들어가면 oxCard 정보가 저장되는지 검증
+	 * 2. keywordCard type 정보가 들어가면 keywordCard 정보가 저장되는지 검증
+	 * 3. multi choice card type 정보가 들어가면 MultiChoiceCard 정보가 저장되는 지 검증
+	 */
+	@Nested
+	@DisplayName("카드 저장 테스트")
+	class SaveCardTest {
+		@Test
+		@DisplayName("oxCard type정보가 들어가면 oxCard 정보가 저장되는지 검증")
+		void shouldSaveOxCardTest() {
+			cardService.saveCard(makeSaveCardRequest().oxAnswer(OxAnswer.O).cardType(CardType.OX_QUIZ).build(),
+				Id.generateNextId());
+			List<OxCard> all = oxCardRepository.findAll();
+			assertThat(all).isNotEmpty();
+		}
+
+		@Test
+		@DisplayName("keywordCard type 정보가 들어가면 keywordCard 정보가 저장되는지 검증")
+		void shouldSaveKeywordCardTest() {
+			cardService.saveCard(makeSaveCardRequest()
+				.keywordAnswer(new KeywordAnswer("asdf"))
+				.cardType(CardType.KEYWORD).build(), Id.generateNextId());
+			List<KeywordCard> all = keywordCardRepository.findAll();
+			assertThat(all).isNotEmpty();
+		}
+
+		@Test
+		@DisplayName("multi choice card type 정보가 들어가면 MultiChoiceCard 정보가 저장되는 지 검증")
+		void shouldSaveMultiCardTest() {
+			cardService.saveCard(
+				makeSaveCardRequest().multiChoiceAnswer(new MultiChoiceAnswer(1))
+					.cardType(CardType.MULTI_CHOICE).build(),
+				Id.generateNextId());
+			List<MultiChoiceCard> all = multiChoiceCardRepository.findAll();
+			assertThat(all).isNotEmpty();
+		}
+
+		private SaveCardRequestDto.SaveCardRequestDtoBuilder makeSaveCardRequest() {
+			return SaveCardRequestDto.builder()
+				.title(new Title("title"))
+				.question(new Question("question"))
+				.categoryId(Id.generateNextId())
+				.images("A,B,C");
+		}
 	}
 
-	@Test
-	@DisplayName("keywordCard type 정보가 들어가면 keywordCard 정보가 저장되는지 검증")
-	void shouldSaveKeywordCardTest() {
-		cardService.saveCard(makeSaveCardRequest()
-			.keywordAnswer(new KeywordAnswer("asdf"))
-			.cardType(CardType.KEYWORD).build(), Id.generateNextId());
-		List<KeywordCard> all = keywordCardRepository.findAll();
-		assertThat(all).isNotEmpty();
-	}
-
-	@Test
-	@DisplayName("multi choice card type 정보가 들어가면 MultiChoiceCard 정보가 저장되는 지 검증")
-	void shouldSaveMultiCardTest() {
-		cardService.saveCard(
-			makeSaveCardRequest().multiChoiceAnswer(new MultiChoiceAnswer(1))
-				.cardType(CardType.MULTI_CHOICE).build(),
-			Id.generateNextId());
-		List<MultiChoiceCard> all = multiChoiceCardRepository.findAll();
-		assertThat(all).isNotEmpty();
-	}
-
-	private SaveCardRequestDto.SaveCardRequestDtoBuilder makeSaveCardRequest() {
-		return SaveCardRequestDto.builder()
-			.title(new Title("title"))
-			.question(new Question("question"))
-			.categoryId(Id.generateNextId())
-			.images("A,B,C");
-	}
 }

--- a/src/test/java/com/almondia/meca/card/sevice/checker/CardCheckerTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/checker/CardCheckerTest.java
@@ -1,0 +1,68 @@
+package com.almondia.meca.card.sevice.checker;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+
+import com.almondia.meca.card.domain.entity.Card;
+import com.almondia.meca.card.domain.entity.OxCard;
+import com.almondia.meca.card.domain.vo.CardType;
+import com.almondia.meca.card.domain.vo.Question;
+import com.almondia.meca.card.repository.OxCardRepository;
+import com.almondia.meca.common.configuration.jpa.QueryDslConfiguration;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 1. 카드Id가 본인 소유와 일치한다면 카드 반환
+ * 2. 카드Id가 본인 소유가 아닌 경우 권한 에러
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({CardChecker.class, QueryDslConfiguration.class})
+class CardCheckerTest {
+
+	@Autowired
+	OxCardRepository oxCardRepository;
+
+	@Autowired
+	CardChecker cardChecker;
+
+	@Test
+	@DisplayName("카드Id가 본인 소유와 일치한다면 카드 반환")
+	void shouldReturnCardWhenCardIdIsMineTest() {
+		Id cardId = Id.generateNextId();
+		Id categoryId = Id.generateNextId();
+		Id memberId = Id.generateNextId();
+		saveCard(cardId, categoryId, memberId);
+		Card card = cardChecker.checkAuthority(cardId, memberId, CardType.OX_QUIZ);
+		assertThat(card).isInstanceOf(Card.class);
+	}
+
+	@Test
+	@DisplayName("카드Id가 본인 소유가 아닌 경우 권한 에러")
+	void shouldThrowAccessDeniedExceptionWhenNotMyCardRequestTest() {
+		Id cardId = Id.generateNextId();
+		Id categoryId = Id.generateNextId();
+		Id memberId = Id.generateNextId();
+		saveCard(cardId, categoryId, memberId);
+		assertThatThrownBy(
+			() -> cardChecker.checkAuthority(cardId, Id.generateNextId(), CardType.OX_QUIZ)).isInstanceOf(
+			AccessDeniedException.class);
+	}
+
+	private void saveCard(Id cardId, Id categoryId, Id memberId) {
+		oxCardRepository.save(OxCard.builder()
+			.cardId(cardId)
+			.cardType(CardType.OX_QUIZ)
+			.question(new Question("question"))
+			.memberId(memberId)
+			.categoryId(categoryId)
+			.build());
+	}
+}

--- a/src/test/java/com/almondia/meca/card/sevice/helper/CardFactoryTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/helper/CardFactoryTest.java
@@ -31,10 +31,11 @@ class CardFactoryTest {
 		Card card = CardFactory.genCard(makeSaveCardRequest()
 			.oxAnswer(OxAnswer.O)
 			.cardType(CardType.OX_QUIZ)
-			.build());
+			.build(), Id.generateNextId());
 		assertThat(card).isInstanceOf(OxCard.class);
 		assertThat(card).hasFieldOrProperty("title")
 			.hasFieldOrProperty("question")
+			.hasFieldOrProperty("memberId")
 			.hasFieldOrProperty("categoryId")
 			.hasFieldOrProperty("images")
 			.hasFieldOrProperty("cardType")
@@ -48,11 +49,12 @@ class CardFactoryTest {
 		Card card = CardFactory.genCard(makeSaveCardRequest()
 			.keywordAnswer(new KeywordAnswer("개발자"))
 			.cardType(CardType.KEYWORD)
-			.build());
+			.build(), Id.generateNextId());
 		assertThat(card).isInstanceOf(KeywordCard.class);
 		assertThat(card).hasFieldOrProperty("title")
 			.hasFieldOrProperty("question")
 			.hasFieldOrProperty("categoryId")
+			.hasFieldOrProperty("memberId")
 			.hasFieldOrProperty("images")
 			.hasFieldOrProperty("cardType")
 			.hasFieldOrProperty("cardId")
@@ -65,11 +67,12 @@ class CardFactoryTest {
 		Card card = CardFactory.genCard(makeSaveCardRequest()
 			.multiChoiceAnswer(new MultiChoiceAnswer(1))
 			.cardType(CardType.MULTI_CHOICE)
-			.build());
+			.build(), Id.generateNextId());
 		assertThat(card).isInstanceOf(MultiChoiceCard.class);
 		assertThat(card).hasFieldOrProperty("title")
 			.hasFieldOrProperty("question")
 			.hasFieldOrProperty("categoryId")
+			.hasFieldOrProperty("memberId")
 			.hasFieldOrProperty("images")
 			.hasFieldOrProperty("cardType")
 			.hasFieldOrProperty("cardId")


### PR DESCRIPTION
## 요약

- uri : [PUT] /api/v1/cards/{cardId}
- 변경 가능한 속성: title, 카테고리 id, 질문, images
- 카드 타입은 식별용으로 넣어주어야 한다