### PR TITLE
fix/#40: 카테고리 페이징 조회 요청시 에러 수정

### DIFF
--- a/src/main/java/com/almondia/meca/category/controller/CategoryController.java
+++ b/src/main/java/com/almondia/meca/category/controller/CategoryController.java
@@ -63,7 +63,7 @@ public class CategoryController {
 		@RequestParam(name = "offset", defaultValue = "0") int offset,
 		@RequestParam(name = "pageSize", defaultValue = "1000") int pageSize,
 		@RequestParam(name = "sortField", defaultValue = "createdAt") CategorySortField sortField,
-		@RequestParam(name = "sortOrder", defaultValue = "asc") SortOrder sortOrder,
+		@RequestParam(name = "sortOrder", defaultValue = "desc") SortOrder sortOrder,
 		@RequestParam(name = "startTitle", required = false) String startTitle,
 		@RequestParam(name = "startCreatedAt", required = false) LocalDateTime startCreatedAt,
 		@RequestParam(name = "endCreatedAt", required = false) LocalDateTime endCreatedAt,

--- a/src/main/java/com/almondia/meca/category/controller/CategoryController.java
+++ b/src/main/java/com/almondia/meca/category/controller/CategoryController.java
@@ -67,8 +67,7 @@ public class CategoryController {
 		@RequestParam(name = "startTitle", required = false) String startTitle,
 		@RequestParam(name = "startCreatedAt", required = false) LocalDateTime startCreatedAt,
 		@RequestParam(name = "endCreatedAt", required = false) LocalDateTime endCreatedAt,
-		@RequestParam(name = "eqShared", defaultValue = "false") Boolean eqShared,
-		@RequestParam(name = "eqDeleted", defaultValue = "false") Boolean eqDeleted
+		@RequestParam(name = "eqShared", defaultValue = "false") Boolean eqShared
 	) {
 		CategorySearchCriteria categorySearchCriteria = CategorySearchCriteria.builder()
 			.startsWithTitle(startTitle)
@@ -76,7 +75,6 @@ public class CategoryController {
 			.endCreatedAt(endCreatedAt)
 			.eqMemberId(member.getMemberId())
 			.eqShared(eqShared)
-			.eqDeleted(eqDeleted)
 			.build();
 		SortOption<CategorySortField> sortOption = SortOption.of(sortField, sortOrder);
 		OffsetPage<CategoryResponseDto> responseDto = categoryService.getOffsetPagingCategoryResponseDto(

--- a/src/main/java/com/almondia/meca/common/configuration/web/WebMvcConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/configuration/web/WebMvcConfiguration.java
@@ -1,8 +1,10 @@
 package com.almondia.meca.common.configuration.web;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Configuration
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
 	@Override

--- a/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
@@ -167,7 +167,7 @@ class CategoryControllerTest {
 			Mockito.doReturn(response)
 				.when(categoryservice).getOffsetPagingCategoryResponseDto(anyInt(), anyInt(), any(), any());
 
-			final String url = "/api/v1/categories/me?offset=2&pageSize=4&createdAt&startCreatedAt=2023-03-13T10:23";
+			final String url = "/api/v1/categories/me?offset=2&pageSize=4&sortField=createdAt&startCreatedAt=2023-03-13T10:23";
 			mockMvc.perform(get(url))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("contents").exists())


### PR DESCRIPTION
## 요약

- 테스트 코드에서와 달리 WebMvcConfiguration 객체에 Configuration 어노테이션을 붙이지 않아 spring에서 bean으로 인식을 못해서 발생하는 문제
- 이제 컨버터가 모두 정상적으로 동작하고,  createdAt을 요청했을때 정상적으로 동작