### PR TITLE
refactor/#43: ID를 ULID 기반 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // ulid-creator
+    implementation group: 'com.github.f4b6a3', name: 'ulid-creator', version: '5.1.0'
+
     // mock web server
     testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
 

--- a/src/main/java/com/almondia/meca/common/domain/vo/Id.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/Id.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 import javax.persistence.Embeddable;
 
 import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+import com.github.f4b6a3.ulid.Ulid;
+import com.github.f4b6a3.ulid.UlidCreator;
 
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -14,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Embeddable
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Id implements Serializable, Wrapper {
+public class Id implements Serializable, Wrapper, Comparable<Id> {
 
 	private static final long serialVersionUID = -2772995063676474658L;
 
@@ -29,12 +31,17 @@ public class Id implements Serializable, Wrapper {
 	}
 
 	public static Id generateNextId() {
-		UUID uuid = UUID.randomUUID();
-		return new Id(uuid);
+		Ulid ulid = UlidCreator.getMonotonicUlid();
+		return new Id(ulid.toUuid());
 	}
 
 	@Override
 	public String toString() {
 		return uuid.toString();
+	}
+
+	@Override
+	public int compareTo(Id o) {
+		return this.uuid.compareTo(o.uuid);
 	}
 }

--- a/src/test/java/com/almondia/meca/common/domain/vo/IdTest.java
+++ b/src/test/java/com/almondia/meca/common/domain/vo/IdTest.java
@@ -3,6 +3,7 @@ package com.almondia.meca.common.domain.vo;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +15,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * 직렬화/역직렬화 테스트
+ * 1. 직렬화/역직렬화 테스트
+ * 2. 생성 순서에 따른 대소 비교 테스트
  */
 @ExtendWith(SpringExtension.class)
 @Import({JacksonConfiguration.class})
@@ -39,5 +41,13 @@ class IdTest {
 		String jsonInput = "\"" + id + "\"";
 		Id result = objectMapper.readValue(jsonInput, Id.class);
 		assertThat(result).isEqualTo(id);
+	}
+
+	@RepeatedTest(value = 10)
+	@DisplayName("id 생성시간 별 대소 비교 테스트")
+	void genOrderCompareTest() {
+		Id id1 = Id.generateNextId();
+		Id id2 = Id.generateNextId();
+		assertThat(id1).isLessThan(id2);
 	}
 }


### PR DESCRIPTION
## 요약

- ulid-creator 오픈소스를 활용해 ULID 기반 ID 생성
- 앱이 UUID 기반으로 설계되었기 때문에 ulid -> uuid로 변환해서 사용
    - 생성이 중간에 변환이 하나 추가되었기 때문에 성능에 문제가 된다면 uuid로 컨버터 하는 과정을 없애고 리팩토링 해야함