### PR TITLE
refactor/#42: 카드 요청, 응답 단일화

### DIFF
--- a/src/main/java/com/almondia/meca/card/controller/dto/CardResponseDto.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/CardResponseDto.java
@@ -5,9 +5,6 @@ import java.util.List;
 
 import com.almondia.meca.card.domain.vo.CardType;
 import com.almondia.meca.card.domain.vo.Image;
-import com.almondia.meca.card.domain.vo.KeywordAnswer;
-import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
-import com.almondia.meca.card.domain.vo.OxAnswer;
 import com.almondia.meca.card.domain.vo.Question;
 import com.almondia.meca.card.domain.vo.Title;
 import com.almondia.meca.common.domain.vo.Id;
@@ -30,7 +27,5 @@ public class CardResponseDto {
 	private final boolean isDeleted;
 	private final LocalDateTime createdAt;
 	private final LocalDateTime modifiedAt;
-	private final OxAnswer oxAnswer;
-	private final KeywordAnswer keywordAnswer;
-	private final MultiChoiceAnswer multiChoiceAnswer;
+	private final String answer;
 }

--- a/src/main/java/com/almondia/meca/card/controller/dto/SaveCardRequestDto.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/SaveCardRequestDto.java
@@ -1,9 +1,6 @@
 package com.almondia.meca.card.controller.dto;
 
 import com.almondia.meca.card.domain.vo.CardType;
-import com.almondia.meca.card.domain.vo.KeywordAnswer;
-import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
-import com.almondia.meca.card.domain.vo.OxAnswer;
 import com.almondia.meca.card.domain.vo.Question;
 import com.almondia.meca.card.domain.vo.Title;
 import com.almondia.meca.common.domain.vo.Id;
@@ -25,7 +22,5 @@ public class SaveCardRequestDto {
 	private Id categoryId;
 	private String images;
 	private CardType cardType;
-	private OxAnswer oxAnswer;
-	private KeywordAnswer keywordAnswer;
-	private MultiChoiceAnswer multiChoiceAnswer;
+	private String answer;
 }

--- a/src/main/java/com/almondia/meca/card/domain/vo/KeywordAnswer.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/KeywordAnswer.java
@@ -27,4 +27,9 @@ public class KeywordAnswer implements Wrapper {
 			throw new IllegalArgumentException("%d 초과해서 문자열 길이를 늘릴 수 없습니다");
 		}
 	}
+
+	@Override
+	public String toString() {
+		return keywordAnswer;
+	}
 }

--- a/src/main/java/com/almondia/meca/card/domain/vo/MultiChoiceAnswer.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/MultiChoiceAnswer.java
@@ -28,4 +28,9 @@ public class MultiChoiceAnswer implements Wrapper {
 			throw new IllegalArgumentException(String.format("%d부터 %d숫자만 입력 가능합니다", MIN_NUMBER, MAX_NUMBER));
 		}
 	}
+
+	@Override
+	public String toString() {
+		return number.toString();
+	}
 }

--- a/src/main/java/com/almondia/meca/card/sevice/helper/CardFactory.java
+++ b/src/main/java/com/almondia/meca/card/sevice/helper/CardFactory.java
@@ -11,6 +11,9 @@ import com.almondia.meca.card.domain.entity.MultiChoiceCard;
 import com.almondia.meca.card.domain.entity.OxCard;
 import com.almondia.meca.card.domain.vo.CardType;
 import com.almondia.meca.card.domain.vo.Image;
+import com.almondia.meca.card.domain.vo.KeywordAnswer;
+import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
+import com.almondia.meca.card.domain.vo.OxAnswer;
 import com.almondia.meca.common.domain.vo.Id;
 
 public class CardFactory {
@@ -32,6 +35,7 @@ public class CardFactory {
 	}
 
 	private static OxCard genOxCard(SaveCardRequestDto saveCardRequestDto, Id memberId) {
+		String answer = saveCardRequestDto.getAnswer();
 		return OxCard.builder()
 			.cardId(Id.generateNextId())
 			.memberId(memberId)
@@ -40,11 +44,12 @@ public class CardFactory {
 			.categoryId(saveCardRequestDto.getCategoryId())
 			.cardType(saveCardRequestDto.getCardType())
 			.images(makeImages(saveCardRequestDto.getImages()))
-			.oxAnswer(saveCardRequestDto.getOxAnswer())
+			.oxAnswer(OxAnswer.valueOf(answer.toUpperCase()))
 			.build();
 	}
 
 	private static KeywordCard genKeywordCard(SaveCardRequestDto saveCardRequestDto, Id memberId) {
+		String answer = saveCardRequestDto.getAnswer();
 		return KeywordCard.builder()
 			.cardId(Id.generateNextId())
 			.memberId(memberId)
@@ -53,11 +58,12 @@ public class CardFactory {
 			.categoryId(saveCardRequestDto.getCategoryId())
 			.cardType(saveCardRequestDto.getCardType())
 			.images(makeImages(saveCardRequestDto.getImages()))
-			.keywordAnswer(saveCardRequestDto.getKeywordAnswer())
+			.keywordAnswer(new KeywordAnswer(answer))
 			.build();
 	}
 
 	private static MultiChoiceCard genMultiChoiceCard(SaveCardRequestDto saveCardRequestDto, Id memberId) {
+		String answer = saveCardRequestDto.getAnswer();
 		return MultiChoiceCard.builder()
 			.cardId(Id.generateNextId())
 			.memberId(memberId)
@@ -66,7 +72,7 @@ public class CardFactory {
 			.categoryId(saveCardRequestDto.getCategoryId())
 			.cardType(saveCardRequestDto.getCardType())
 			.images(makeImages(saveCardRequestDto.getImages()))
-			.multiChoiceAnswer(saveCardRequestDto.getMultiChoiceAnswer())
+			.multiChoiceAnswer(new MultiChoiceAnswer(Integer.parseInt(answer)))
 			.build();
 	}
 

--- a/src/main/java/com/almondia/meca/card/sevice/helper/CardMapper.java
+++ b/src/main/java/com/almondia/meca/card/sevice/helper/CardMapper.java
@@ -18,7 +18,7 @@ public class CardMapper {
 			.isDeleted(oxCard.isDeleted())
 			.createdAt(oxCard.getCreatedAt())
 			.modifiedAt(oxCard.getModifiedAt())
-			.oxAnswer(oxCard.getOxAnswer())
+			.answer(oxCard.getOxAnswer().name())
 			.build();
 	}
 
@@ -33,7 +33,7 @@ public class CardMapper {
 			.isDeleted(keywordCard.isDeleted())
 			.createdAt(keywordCard.getCreatedAt())
 			.modifiedAt(keywordCard.getModifiedAt())
-			.keywordAnswer(keywordCard.getKeywordAnswer())
+			.answer(keywordCard.getKeywordAnswer().toString())
 			.build();
 	}
 
@@ -48,7 +48,7 @@ public class CardMapper {
 			.isDeleted(multiChoiceCard.isDeleted())
 			.createdAt(multiChoiceCard.getCreatedAt())
 			.modifiedAt(multiChoiceCard.getModifiedAt())
-			.multiChoiceAnswer(multiChoiceCard.getMultiChoiceAnswer())
+			.answer(multiChoiceCard.getMultiChoiceAnswer().toString())
 			.build();
 	}
 }

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -68,7 +68,7 @@ class CardControllerTest {
 				.images("A,B,C,D")
 				.categoryId(Id.generateNextId())
 				.cardType(CardType.OX_QUIZ)
-				.oxAnswer(OxAnswer.O)
+				.answer(OxAnswer.O.toString())
 				.build();
 			Mockito.doReturn(makeResponse()).when(cardService).saveCard(any(), any());
 

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -2,22 +2,25 @@ package com.almondia.meca.card.controller;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 import com.almondia.meca.card.controller.dto.CardResponseDto;
 import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
@@ -35,7 +38,6 @@ import com.almondia.meca.mock.security.WithMockMember;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(CardController.class)
-@AutoConfigureMockMvc(addFilters = false)
 @Import({JacksonConfiguration.class})
 class CardControllerTest {
 
@@ -46,10 +48,20 @@ class CardControllerTest {
 	JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@Autowired
+	WebApplicationContext context;
+
+	@Autowired
 	MockMvc mockMvc;
 
 	@Autowired
 	ObjectMapper objectMapper;
+
+	@BeforeEach
+	void before() {
+		mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.alwaysDo(print())
+			.build();
+	}
 
 	/**
 	 * 1. 요청 성공시 201을 리턴하고 카드 정보를 반환한다.
@@ -86,7 +98,7 @@ class CardControllerTest {
 				.andExpect(jsonPath("created_at").exists())
 				.andExpect(jsonPath("modified_at").exists())
 				.andExpect(jsonPath("title").exists())
-				.andExpect(jsonPath("ox_answer").exists());
+				.andExpect(jsonPath("answer").exists());
 		}
 
 		private CardResponseDto makeResponse() {
@@ -98,7 +110,7 @@ class CardControllerTest {
 				.categoryId(Id.generateNextId())
 				.cardType(CardType.OX_QUIZ)
 				.isDeleted(false)
-				.oxAnswer(OxAnswer.O)
+				.answer(OxAnswer.O.name())
 				.createdAt(LocalDateTime.now())
 				.modifiedAt(LocalDateTime.now())
 				.build();
@@ -140,7 +152,7 @@ class CardControllerTest {
 				.andExpect(jsonPath("created_at").exists())
 				.andExpect(jsonPath("modified_at").exists())
 				.andExpect(jsonPath("title").exists())
-				.andExpect(jsonPath("ox_answer").exists());
+				.andExpect(jsonPath("answer").exists());
 		}
 
 		private CardResponseDto makeResponse() {
@@ -152,7 +164,7 @@ class CardControllerTest {
 				.categoryId(Id.generateNextId())
 				.cardType(CardType.OX_QUIZ)
 				.isDeleted(false)
-				.oxAnswer(OxAnswer.O)
+				.answer(OxAnswer.O.name())
 				.createdAt(LocalDateTime.now())
 				.modifiedAt(LocalDateTime.now())
 				.build();

--- a/src/test/java/com/almondia/meca/card/sevice/CardServiceTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/CardServiceTest.java
@@ -26,8 +26,6 @@ import com.almondia.meca.card.domain.entity.MultiChoiceCard;
 import com.almondia.meca.card.domain.entity.OxCard;
 import com.almondia.meca.card.domain.vo.CardType;
 import com.almondia.meca.card.domain.vo.Image;
-import com.almondia.meca.card.domain.vo.KeywordAnswer;
-import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
 import com.almondia.meca.card.domain.vo.OxAnswer;
 import com.almondia.meca.card.domain.vo.Question;
 import com.almondia.meca.card.domain.vo.Title;
@@ -71,7 +69,7 @@ class CardServiceTest {
 		@Test
 		@DisplayName("oxCard type정보가 들어가면 oxCard 정보가 저장되는지 검증")
 		void shouldSaveOxCardTest() {
-			cardService.saveCard(makeSaveCardRequest().oxAnswer(OxAnswer.O).cardType(CardType.OX_QUIZ).build(),
+			cardService.saveCard(makeSaveCardRequest().answer(OxAnswer.O.toString()).cardType(CardType.OX_QUIZ).build(),
 				Id.generateNextId());
 			List<OxCard> all = oxCardRepository.findAll();
 			assertThat(all).isNotEmpty();
@@ -81,7 +79,7 @@ class CardServiceTest {
 		@DisplayName("keywordCard type 정보가 들어가면 keywordCard 정보가 저장되는지 검증")
 		void shouldSaveKeywordCardTest() {
 			cardService.saveCard(makeSaveCardRequest()
-				.keywordAnswer(new KeywordAnswer("asdf"))
+				.answer("asdf")
 				.cardType(CardType.KEYWORD).build(), Id.generateNextId());
 			List<KeywordCard> all = keywordCardRepository.findAll();
 			assertThat(all).isNotEmpty();
@@ -91,7 +89,7 @@ class CardServiceTest {
 		@DisplayName("multi choice card type 정보가 들어가면 MultiChoiceCard 정보가 저장되는 지 검증")
 		void shouldSaveMultiCardTest() {
 			cardService.saveCard(
-				makeSaveCardRequest().multiChoiceAnswer(new MultiChoiceAnswer(1))
+				makeSaveCardRequest().answer("1")
 					.cardType(CardType.MULTI_CHOICE).build(),
 				Id.generateNextId());
 			List<MultiChoiceCard> all = multiChoiceCardRepository.findAll();

--- a/src/test/java/com/almondia/meca/card/sevice/helper/CardFactoryTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/helper/CardFactoryTest.java
@@ -11,8 +11,6 @@ import com.almondia.meca.card.domain.entity.KeywordCard;
 import com.almondia.meca.card.domain.entity.MultiChoiceCard;
 import com.almondia.meca.card.domain.entity.OxCard;
 import com.almondia.meca.card.domain.vo.CardType;
-import com.almondia.meca.card.domain.vo.KeywordAnswer;
-import com.almondia.meca.card.domain.vo.MultiChoiceAnswer;
 import com.almondia.meca.card.domain.vo.OxAnswer;
 import com.almondia.meca.card.domain.vo.Question;
 import com.almondia.meca.card.domain.vo.Title;
@@ -29,7 +27,7 @@ class CardFactoryTest {
 	@DisplayName("OxCard 속성별 인스턴스를 잘 생성했는지 검증")
 	public void newInstanceOxCardTest() {
 		Card card = CardFactory.genCard(makeSaveCardRequest()
-			.oxAnswer(OxAnswer.O)
+			.answer(OxAnswer.O.toString())
 			.cardType(CardType.OX_QUIZ)
 			.build(), Id.generateNextId());
 		assertThat(card).isInstanceOf(OxCard.class);
@@ -47,7 +45,7 @@ class CardFactoryTest {
 	@DisplayName("KeywordCard 속성별 인스턴스를 잘 생성했는지 검증")
 	public void newInstanceKeywordCardTest() {
 		Card card = CardFactory.genCard(makeSaveCardRequest()
-			.keywordAnswer(new KeywordAnswer("개발자"))
+			.answer("개발자")
 			.cardType(CardType.KEYWORD)
 			.build(), Id.generateNextId());
 		assertThat(card).isInstanceOf(KeywordCard.class);
@@ -65,7 +63,7 @@ class CardFactoryTest {
 	@DisplayName("MultiChoiceCard 속성별 인스턴스를 잘 생성했는지 검증")
 	public void newInstanceMultiChoiceCardTest() {
 		Card card = CardFactory.genCard(makeSaveCardRequest()
-			.multiChoiceAnswer(new MultiChoiceAnswer(1))
+			.answer("1")
 			.cardType(CardType.MULTI_CHOICE)
 			.build(), Id.generateNextId());
 		assertThat(card).isInstanceOf(MultiChoiceCard.class);

--- a/src/test/java/com/almondia/meca/card/sevice/helper/CardMapperTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/helper/CardMapperTest.java
@@ -38,7 +38,7 @@ class CardMapperTest {
 			.hasFieldOrProperty("isDeleted")
 			.hasFieldOrProperty("createdAt")
 			.hasFieldOrProperty("modifiedAt")
-			.hasFieldOrProperty("oxAnswer");
+			.hasFieldOrProperty("answer");
 	}
 
 	@Test
@@ -54,7 +54,7 @@ class CardMapperTest {
 			.hasFieldOrProperty("isDeleted")
 			.hasFieldOrProperty("createdAt")
 			.hasFieldOrProperty("modifiedAt")
-			.hasFieldOrProperty("keywordAnswer");
+			.hasFieldOrProperty("answer");
 	}
 
 	@Test
@@ -70,7 +70,7 @@ class CardMapperTest {
 			.hasFieldOrProperty("isDeleted")
 			.hasFieldOrProperty("createdAt")
 			.hasFieldOrProperty("modifiedAt")
-			.hasFieldOrProperty("multiChoiceAnswer");
+			.hasFieldOrProperty("answer");
 	}
 
 	private OxCard makeOxCard() {


### PR DESCRIPTION
## 요약

- 내부적으로는 분리되지만 요청 응답시에는 문자열타입으로 통합에서 answer 속성으로 제공
- 내부적으로는 분리되어서 유효성 검사를 진행하기 때문에 card_type에 따라 answer를 잘 작성해야함