### PR TITLE
refactor: dto 내부에 있던 categoryId를 path variable로 옮김

### DIFF
--- a/src/main/java/com/almondia/meca/category/controller/CategoryController.java
+++ b/src/main/java/com/almondia/meca/category/controller/CategoryController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +22,7 @@ import com.almondia.meca.category.infra.querydsl.CategorySearchCriteria;
 import com.almondia.meca.category.infra.querydsl.CategorySortField;
 import com.almondia.meca.category.service.CategoryService;
 import com.almondia.meca.common.controller.dto.OffsetPage;
+import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.common.infra.querydsl.SortOption;
 import com.almondia.meca.common.infra.querydsl.SortOrder;
 import com.almondia.meca.member.domain.entity.Member;
@@ -45,14 +47,15 @@ public class CategoryController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(categoryResponseDto);
 	}
 
-	@PutMapping
+	@PutMapping("/{categoryId}")
 	@Secured("ROLE_USER")
 	public ResponseEntity<CategoryResponseDto> updateCategory(
 		@AuthenticationPrincipal Member member,
+		@PathVariable(value = "categoryId") Id categoryId,
 		@RequestBody UpdateCategoryRequestDto updateCategoryRequestDto
 	) {
 		CategoryResponseDto responseDto = categoryService.updateCategory(updateCategoryRequestDto,
-			member.getMemberId());
+			categoryId, member.getMemberId());
 		return ResponseEntity.ok(responseDto);
 	}
 

--- a/src/main/java/com/almondia/meca/category/controller/dto/UpdateCategoryRequestDto.java
+++ b/src/main/java/com/almondia/meca/category/controller/dto/UpdateCategoryRequestDto.java
@@ -1,7 +1,6 @@
 package com.almondia.meca.category.controller.dto;
 
 import com.almondia.meca.category.domain.vo.Title;
-import com.almondia.meca.common.domain.vo.Id;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,7 +14,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UpdateCategoryRequestDto {
 
-	private Id categoryId;
 	private Title title;
 	private Boolean isShared;
 }

--- a/src/main/java/com/almondia/meca/category/service/CategoryService.java
+++ b/src/main/java/com/almondia/meca/category/service/CategoryService.java
@@ -34,8 +34,9 @@ public class CategoryService {
 	}
 
 	@Transactional
-	public CategoryResponseDto updateCategory(UpdateCategoryRequestDto updateCategoryRequestDto, Id memberId) {
-		Category category = categoryChecker.checkAuthority(updateCategoryRequestDto.getCategoryId(), memberId);
+	public CategoryResponseDto updateCategory(UpdateCategoryRequestDto updateCategoryRequestDto, Id categoryId,
+		Id memberId) {
+		Category category = categoryChecker.checkAuthority(categoryId, memberId);
 		if (updateCategoryRequestDto.getTitle() != null) {
 			category.changeTitle(updateCategoryRequestDto.getTitle());
 		}

--- a/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
@@ -111,8 +111,8 @@ class CategoryControllerTest {
 					.createdAt(LocalDateTime.now())
 					.modifiedAt(LocalDateTime.now())
 					.build())
-				.when(categoryservice).updateCategory(any(), any());
-			mockMvc.perform(put("/api/v1/categories")
+				.when(categoryservice).updateCategory(any(), any(), any());
+			mockMvc.perform(put("/api/v1/categories/{categoryId}", Id.generateNextId())
 					.contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8)
 					.content(makeCategoryRequestDto()))
@@ -131,8 +131,8 @@ class CategoryControllerTest {
 		@DisplayName("권한 오류가 발생시 403 응답 반환")
 		void shouldThrowWhenAuthorizationErrorTest() throws Exception {
 			Mockito.doThrow(new AccessDeniedException("권한 없음"))
-				.when(categoryservice).updateCategory(any(), any());
-			mockMvc.perform(put("/api/v1/categories")
+				.when(categoryservice).updateCategory(any(), any(), any());
+			mockMvc.perform(put("/api/v1/categories/{categoryId}", Id.generateNextId())
 					.contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8)
 					.content(makeCategoryRequestDto()))
@@ -141,7 +141,6 @@ class CategoryControllerTest {
 
 		private String makeCategoryRequestDto() throws JsonProcessingException {
 			UpdateCategoryRequestDto updateCategoryRequestDto = UpdateCategoryRequestDto.builder()
-				.categoryId(Id.generateNextId())
 				.title(new Title("title"))
 				.build();
 			return objectMapper.writeValueAsString(updateCategoryRequestDto);

--- a/src/test/java/com/almondia/meca/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/almondia/meca/category/service/CategoryServiceTest.java
@@ -53,18 +53,13 @@ class CategoryServiceTest {
 		Id memberId = Id.generateNextId();
 		saveCategory(categoryId, memberId);
 		CategoryResponseDto category = categoryService.updateCategory(
-			UpdateCategoryRequestDto.builder()
-				.categoryId(categoryId)
-				.title(new Title("new title")).build(), memberId);
+			UpdateCategoryRequestDto.builder().title(new Title("new title")).build(), categoryId, memberId);
 		List<Category> all = categoryRepository.findAll();
 		assertThat(all.get(0).getTitle()).isEqualTo(new Title("new title"));
 	}
 
 	private void saveCategory(Id categoryId, Id memberId) {
-		categoryRepository.save(Category.builder()
-			.categoryId(categoryId)
-			.memberId(memberId)
-			.title(new Title("title"))
-			.build());
+		categoryRepository.save(
+			Category.builder().categoryId(categoryId).memberId(memberId).title(new Title("title")).build());
 	}
 }


### PR DESCRIPTION
# 요약

- dto 내부에 있던 categoryId를 path variable로 옮김