### PR TITLE
fix: jwtFilter의 예외 핸들링 안되는 부분 수정

### DIFF
--- a/src/test/java/com/almondia/meca/common/configuration/security/filter/FakeHttpServletResponse.java
+++ b/src/test/java/com/almondia/meca/common/configuration/security/filter/FakeHttpServletResponse.java
@@ -1,0 +1,198 @@
+package com.almondia.meca.common.configuration.security.filter;
+
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Locale;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+public class FakeHttpServletResponse implements HttpServletResponse {
+	private int status;
+
+	@Override
+	public void addCookie(Cookie cookie) {
+
+	}
+
+	@Override
+	public boolean containsHeader(String name) {
+		return false;
+	}
+
+	@Override
+	public String encodeURL(String url) {
+		return null;
+	}
+
+	@Override
+	public String encodeRedirectURL(String url) {
+		return null;
+	}
+
+	@Override
+	public String encodeUrl(String url) {
+		return null;
+	}
+
+	@Override
+	public String encodeRedirectUrl(String url) {
+		return null;
+	}
+
+	@Override
+	public void sendError(int sc, String msg) {
+
+	}
+
+	@Override
+	public void sendError(int sc) {
+
+	}
+
+	@Override
+	public void sendRedirect(String location) {
+
+	}
+
+	@Override
+	public void setDateHeader(String name, long date) {
+
+	}
+
+	@Override
+	public void addDateHeader(String name, long date) {
+
+	}
+
+	@Override
+	public void setHeader(String name, String value) {
+
+	}
+
+	@Override
+	public void addHeader(String name, String value) {
+
+	}
+
+	@Override
+	public void setIntHeader(String name, int value) {
+
+	}
+
+	@Override
+	public void addIntHeader(String name, int value) {
+
+	}
+
+	@Override
+	public void setStatus(int sc) {
+		this.status = sc;
+	}
+
+	@Override
+	public void setStatus(int sc, String sm) {
+
+	}
+
+	@Override
+	public int getStatus() {
+		return status;
+	}
+
+	@Override
+	public String getHeader(String name) {
+		return null;
+	}
+
+	@Override
+	public Collection<String> getHeaders(String name) {
+		return null;
+	}
+
+	@Override
+	public Collection<String> getHeaderNames() {
+		return null;
+	}
+
+	@Override
+	public String getCharacterEncoding() {
+		return null;
+	}
+
+	@Override
+	public String getContentType() {
+		return null;
+	}
+
+	@Override
+	public ServletOutputStream getOutputStream() {
+		return null;
+	}
+
+	@Override
+	public PrintWriter getWriter() {
+		return null;
+	}
+
+	@Override
+	public void setCharacterEncoding(String charset) {
+
+	}
+
+	@Override
+	public void setContentLength(int len) {
+
+	}
+
+	@Override
+	public void setContentLengthLong(long length) {
+
+	}
+
+	@Override
+	public void setContentType(String type) {
+
+	}
+
+	@Override
+	public void setBufferSize(int size) {
+
+	}
+
+	@Override
+	public int getBufferSize() {
+		return 0;
+	}
+
+	@Override
+	public void flushBuffer() {
+
+	}
+
+	@Override
+	public void resetBuffer() {
+
+	}
+
+	@Override
+	public boolean isCommitted() {
+		return false;
+	}
+
+	@Override
+	public void reset() {
+
+	}
+
+	@Override
+	public void setLocale(Locale loc) {
+
+	}
+
+	@Override
+	public Locale getLocale() {
+		return null;
+	}
+}

--- a/src/test/java/com/almondia/meca/common/configuration/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/almondia/meca/common/configuration/security/filter/JwtAuthenticationFilterTest.java
@@ -1,5 +1,6 @@
 package com.almondia.meca.common.configuration.security.filter;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 
 import java.io.IOException;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
 
 import com.almondia.meca.auth.jwt.service.JwtTokenService;
 import com.almondia.meca.common.domain.vo.Id;
@@ -28,6 +30,8 @@ import com.almondia.meca.member.service.MemberService;
  * 1. 해당 필터는 access token이 입력되지 않았다면 그냥 통과한다
  * 2. access token이 존재할 떄 옳바르지 않다면 response에 에러를 넣고 401상태를 응답하며 더 이상 필터를 통과시키지 않는다
  * 3. access token이 정상적이라면 securityContextHolder에 authentication을 등록하고 필터를 통과시킨다
+ * 4. 주입한 tokenService에서 예외 발생시 예외를 처리해야 한다
+ * 5. 주입한 memberService에서 예외 발생시 예외를 처리해야 한다
  */
 class JwtAuthenticationFilterTest {
 
@@ -55,7 +59,7 @@ class JwtAuthenticationFilterTest {
 	@BeforeEach
 	void initialize() {
 		request = Mockito.mock(HttpServletRequest.class);
-		response = Mockito.mock(HttpServletResponse.class);
+		response = Mockito.spy(FakeHttpServletResponse.class);
 		filterChain = Mockito.mock(FilterChain.class);
 	}
 
@@ -85,12 +89,40 @@ class JwtAuthenticationFilterTest {
 		IOException {
 
 		String validToken = "asda1231aad";
+		Mockito.doReturn("Bearer " + validToken).when(request).getHeader("Authorization");
 		Mockito.doReturn(true).when(jwtTokenService).isValidToken(validToken);
 		Mockito.doReturn(Id.generateNextId().toString()).when(jwtTokenService).getIdFromToken(validToken);
-		Mockito.doReturn("Bearer " + validToken).when(request).getHeader("Authorization");
 
 		jwtAuthenticationFilter.doFilter(request, response, filterChain);
 
 		Mockito.verify(filterChain, Mockito.atLeastOnce()).doFilter(request, response);
+	}
+
+	@Test
+	@DisplayName("주입한 tokenService에서 예외 발생시 예외를 처리해야 한다")
+	void shouldHandleExceptionWhenThrowByTokenServiceTest() throws ServletException, IOException {
+		String validToken = "asda1231aad";
+		Mockito.doReturn("Bearer " + validToken).when(request).getHeader("Authorization");
+		Mockito.doThrow(IllegalArgumentException.class).when(jwtTokenService).isValidToken(any());
+
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+		Mockito.verify(filterChain, Mockito.never()).doFilter(request, response);
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+	}
+
+	@Test
+	@DisplayName("주입한 memberService에서 예외 발생시 예외를 처리해야 한다")
+	void shouldHandleExceptionWhenThrowByMemberServiceTest() throws ServletException, IOException {
+		String validToken = "asda1231aad";
+		Mockito.doReturn("Bearer " + validToken).when(request).getHeader("Authorization");
+		Mockito.doReturn(true).when(jwtTokenService).isValidToken(any());
+		Mockito.doReturn(Id.generateNextId().toString()).when(jwtTokenService).getIdFromToken(anyString());
+		Mockito.doThrow(IllegalArgumentException.class).when(memberService).findMember(any());
+
+		jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+		Mockito.verify(filterChain, Mockito.never()).doFilter(request, response);
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
 	}
 }


### PR DESCRIPTION
## 요약

- 주입받은 tokenService나 memberService에서 illegalArgumentException 발생시 핸들링하지 않던 문제를 수정