### PR TITLE
feat/#54: 카드 히스토리 엔티티 추가

### DIFF
--- a/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
@@ -1,0 +1,57 @@
+package com.almondia.meca.cardhistory.domain.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.almondia.meca.cardhistory.domain.vo.Answer;
+import com.almondia.meca.cardhistory.domain.vo.Score;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "card_history")
+@Getter
+public class CardHistory {
+
+	@EmbeddedId
+	@AttributeOverride(name = "uuid", column = @Column(name = "card_history_id", nullable = false, columnDefinition = "BINARY(16)"))
+	Id cardHistoryId;
+
+	@Embedded
+	@AttributeOverride(name = "uuid", column = @Column(name = "card_id", nullable = false, columnDefinition = "BINARY(16)"))
+	Id cardId;
+
+	@Embedded
+	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, columnDefinition = "BINARY(16)"))
+	Id categoryId;
+
+	@Embedded
+	@AttributeOverride(name = "answer", column = @Column(name = "user_answer", nullable = false, length = 25))
+	Answer userAnswer;
+
+	@Embedded
+	@AttributeOverride(name = "score", column = @Column(name = "score", nullable = false))
+	Score score;
+
+	@CreatedDate
+	LocalDateTime createdAt;
+}

--- a/src/main/java/com/almondia/meca/cardhistory/domain/vo/Answer.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/vo/Answer.java
@@ -1,0 +1,38 @@
+package com.almondia.meca.cardhistory.domain.vo;
+
+import javax.persistence.Embeddable;
+
+import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Answer implements Wrapper {
+
+	private static final int MAX_LENGTH = 20;
+
+	private String answer;
+
+	public Answer(String answer) {
+		validateAnswer(answer);
+		this.answer = answer;
+	}
+
+	@Override
+	public String toString() {
+		return answer;
+	}
+
+	private void validateAnswer(String answer) {
+		if (answer.length() > MAX_LENGTH) {
+			throw new IllegalArgumentException(String.format("%d 초과로 입력할 수 없습니다", MAX_LENGTH));
+		}
+		if (answer.isBlank()) {
+			throw new IllegalArgumentException("공백을 입력으로 받을 수 없습니다");
+		}
+	}
+}

--- a/src/main/java/com/almondia/meca/cardhistory/domain/vo/Score.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/vo/Score.java
@@ -1,0 +1,39 @@
+package com.almondia.meca.cardhistory.domain.vo;
+
+import javax.persistence.Embeddable;
+
+import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Score implements Wrapper {
+
+	private static final int MAX_SCORE = 100;
+	private static final int MIN_SCORE = 0;
+
+	private int score;
+
+	public Score(int score) {
+		validateScore(score);
+		this.score = score;
+	}
+
+	@Override
+	public String toString() {
+		return String.valueOf(score);
+	}
+
+	private void validateScore(int score) {
+		if (score > MAX_SCORE) {
+			throw new IllegalArgumentException(String.format("%d 점수를 초과할 수 없습니다", MAX_SCORE));
+		}
+		if (score < MIN_SCORE) {
+			throw new IllegalArgumentException("점수는 음수가 될 수 없습니다");
+		}
+	}
+}

--- a/src/test/java/com/almondia/meca/cardhistory/domain/entity/CardHistoryTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/domain/entity/CardHistoryTest.java
@@ -1,0 +1,58 @@
+package com.almondia.meca.cardhistory.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.metamodel.EntityType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.almondia.meca.cardhistory.domain.vo.Answer;
+import com.almondia.meca.cardhistory.domain.vo.Score;
+import com.almondia.meca.common.configuration.jpa.JpaAuditingConfiguration;
+import com.almondia.meca.common.configuration.jpa.QueryDslConfiguration;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * 1. 데이터 속성 생성 테스트
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfiguration.class, QueryDslConfiguration.class})
+class CardHistoryTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	@DisplayName("데이터 속성 생성 테스트")
+	void oxCardAttributeCreationTest() {
+		EntityType<?> entityType = entityManager.getMetamodel().entity(CardHistory.class);
+		assertThat(entityType).isNotNull();
+		assertThat(entityType.getName()).isEqualTo("CardHistory");
+		assertThat(entityType.getAttributes()).extracting("name")
+			.containsExactlyInAnyOrder("categoryId", "cardId", "cardHistoryId", "score", "userAnswer", "createdAt");
+	}
+
+	@Test
+	@DisplayName("엔티티 생성일자 자동 생성 테스트")
+	void autogenCreatedAtWhenSaveEntityTest() {
+		CardHistory cardHistory = CardHistory.builder()
+			.cardId(Id.generateNextId())
+			.cardHistoryId(Id.generateNextId())
+			.categoryId(Id.generateNextId())
+			.userAnswer(new Answer("answer asdfa"))
+			.score(new Score(100))
+			.build();
+		entityManager.persist(cardHistory);
+		LocalDateTime createdAt = cardHistory.getCreatedAt();
+		assertThat(createdAt).isNotNull();
+	}
+}

--- a/src/test/java/com/almondia/meca/cardhistory/domain/vo/AnswerTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/domain/vo/AnswerTest.java
@@ -1,0 +1,26 @@
+package com.almondia.meca.cardhistory.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 1. 길이가 20 초과시 예외 발생
+ * 2. 공백을 입력으로 받을 시 예외
+ */
+class AnswerTest {
+
+	@Test
+	@DisplayName("길이가 20 초과시 예외 발생")
+	void shouldThrowWhenLengthMoreThan20Test() {
+		assertThatThrownBy(() -> new Answer("a".repeat(21))).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("공백을 입력으로 받을 시 예외")
+	void shouldThrowWhenBlankTest() {
+		assertThatThrownBy(() -> new Answer("   ")).isInstanceOf(IllegalArgumentException.class);
+	}
+
+}

--- a/src/test/java/com/almondia/meca/cardhistory/domain/vo/ScoreTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/domain/vo/ScoreTest.java
@@ -1,0 +1,25 @@
+package com.almondia.meca.cardhistory.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 1. Score 객체는 음수로 초기화 할 수 없다
+ * 2. Score 객체는 100 이하의 점수만 생성 가능하다
+ */
+class ScoreTest {
+
+	@Test
+	@DisplayName("Score 객체는 음수로 초기화 할 수 없다")
+	void scoreInstanceMustNotBeNegativeTest() {
+		assertThatThrownBy(() -> new Score(-1)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("Score 객체는 100 이하의 점수만 생성 가능하다")
+	void scoreInstanceMustLessOrEqual100Test() {
+		assertThatThrownBy(() -> new Score(101)).isInstanceOf(IllegalArgumentException.class);
+	}
+}


### PR DESCRIPTION
## 요약

- answer, score vo 추가
- 카드 히스토리 엔티티 추가(cardHistoryId, cardId, categoryId, score, userAnswer, createdAt)