### PR TITLE
fix: jackson 모듈의 직/역직렬화 전략을 스네이크에서 카멜 케이스 으로 수정

### DIFF
--- a/src/main/java/com/almondia/meca/common/configuration/jackson/JacksonConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/configuration/jackson/JacksonConfiguration.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Primary;
 import com.almondia.meca.common.configuration.jackson.module.date.LocalDateTimeModule;
 import com.almondia.meca.common.configuration.jackson.module.wrapper.WrapperModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 @Configuration
 public class JacksonConfiguration {
@@ -17,7 +16,6 @@ public class JacksonConfiguration {
 	public ObjectMapper getObjectMapper() {
 		return new ObjectMapper()
 			.registerModule(new LocalDateTimeModule())
-			.registerModule(new WrapperModule())
-			.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
+			.registerModule(new WrapperModule());
 	}
 }

--- a/src/test/java/com/almondia/meca/auth/AuthControllerTest.java
+++ b/src/test/java/com/almondia/meca/auth/AuthControllerTest.java
@@ -61,7 +61,7 @@ class AuthControllerTest {
 				.param("code", "authorizeCode")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.access_token").exists());
+			.andExpect(jsonPath("$.accessToken").exists());
 	}
 
 	@Test

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -87,15 +87,15 @@ class CardControllerTest {
 			mockMvc.perform(post("/api/v1/cards").contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(saveCardRequestDto)))
 				.andExpect(status().isCreated())
-				.andExpect(jsonPath("card_id").exists())
+				.andExpect(jsonPath("cardId").exists())
 				.andExpect(jsonPath("title").exists())
 				.andExpect(jsonPath("question").exists())
 				.andExpect(jsonPath("images").exists())
-				.andExpect(jsonPath("category_id").exists())
+				.andExpect(jsonPath("categoryId").exists())
 				.andExpect(jsonPath("deleted").exists())
-				.andExpect(jsonPath("card_type").exists())
-				.andExpect(jsonPath("created_at").exists())
-				.andExpect(jsonPath("modified_at").exists())
+				.andExpect(jsonPath("cardType").exists())
+				.andExpect(jsonPath("createdAt").exists())
+				.andExpect(jsonPath("modifiedAt").exists())
 				.andExpect(jsonPath("title").exists())
 				.andExpect(jsonPath("answer").exists());
 		}
@@ -140,15 +140,15 @@ class CardControllerTest {
 					put("/api/v1/cards/{cardId}", Id.generateNextId().toString()).contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(requestDto)))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("card_id").exists())
+				.andExpect(jsonPath("cardId").exists())
 				.andExpect(jsonPath("title").exists())
 				.andExpect(jsonPath("question").exists())
 				.andExpect(jsonPath("images").exists())
-				.andExpect(jsonPath("category_id").exists())
+				.andExpect(jsonPath("categoryId").exists())
 				.andExpect(jsonPath("deleted").exists())
-				.andExpect(jsonPath("card_type").exists())
-				.andExpect(jsonPath("created_at").exists())
-				.andExpect(jsonPath("modified_at").exists())
+				.andExpect(jsonPath("cardType").exists())
+				.andExpect(jsonPath("createdAt").exists())
+				.andExpect(jsonPath("modifiedAt").exists())
 				.andExpect(jsonPath("title").exists())
 				.andExpect(jsonPath("answer").exists());
 		}
@@ -189,8 +189,8 @@ class CardControllerTest {
 					get("/api/v1/cards/categories/{categoryId}/me?pageSize=100&sortOrder=desc", Id.generateNextId()))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("contents").exists())
-				.andExpect(jsonPath("page_size").exists())
-				.andExpect(jsonPath("sort_order").exists());
+				.andExpect(jsonPath("pageSize").exists())
+				.andExpect(jsonPath("sortOrder").exists());
 		}
 
 		private CardResponseDto makeResponse() {

--- a/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
@@ -77,13 +77,13 @@ class CategoryControllerTest {
 					.characterEncoding(StandardCharsets.UTF_8)
 					.content(makeCategoryRequestDto()))
 				.andExpect(status().isCreated())
-				.andExpect(jsonPath("category_id").exists())
-				.andExpect(jsonPath("member_id").exists())
+				.andExpect(jsonPath("categoryId").exists())
+				.andExpect(jsonPath("memberId").exists())
 				.andExpect(jsonPath("title").exists())
 				.andExpect(jsonPath("deleted").exists())
 				.andExpect(jsonPath("shared").exists())
-				.andExpect(jsonPath("created_at").exists())
-				.andExpect(jsonPath("modified_at").exists());
+				.andExpect(jsonPath("createdAt").exists())
+				.andExpect(jsonPath("modifiedAt").exists());
 		}
 
 		private String makeCategoryRequestDto() throws JsonProcessingException {
@@ -117,13 +117,13 @@ class CategoryControllerTest {
 					.characterEncoding(StandardCharsets.UTF_8)
 					.content(makeCategoryRequestDto()))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("category_id").exists())
-				.andExpect(jsonPath("member_id").exists())
+				.andExpect(jsonPath("categoryId").exists())
+				.andExpect(jsonPath("memberId").exists())
 				.andExpect(jsonPath("title").exists())
 				.andExpect(jsonPath("deleted").exists())
 				.andExpect(jsonPath("shared").exists())
-				.andExpect(jsonPath("created_at").exists())
-				.andExpect(jsonPath("modified_at").exists());
+				.andExpect(jsonPath("createdAt").exists())
+				.andExpect(jsonPath("modifiedAt").exists());
 		}
 
 		@Test
@@ -170,10 +170,10 @@ class CategoryControllerTest {
 			mockMvc.perform(get(url))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("contents").exists())
-				.andExpect(jsonPath("total_pages").exists())
-				.andExpect(jsonPath("total_elements").exists())
-				.andExpect(jsonPath("page_number").exists())
-				.andExpect(jsonPath("page_size").exists())
+				.andExpect(jsonPath("totalPages").exists())
+				.andExpect(jsonPath("totalElements").exists())
+				.andExpect(jsonPath("pageNumber").exists())
+				.andExpect(jsonPath("pageSize").exists())
 				.andDo(print());
 		}
 	}

--- a/src/test/java/com/almondia/meca/common/configuration/jackson/JacksonConfigurationTest.java
+++ b/src/test/java/com/almondia/meca/common/configuration/jackson/JacksonConfigurationTest.java
@@ -31,13 +31,12 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * 1. 직렬화/역직렬화 수행시 snake_case를 기준으로 동작해야 한다
- * 2. 날짜 데이터도 어노테이션 사용 없이 직렬화/역직렬화가 잘 동작해야 한다
- * 3. 원시 래핑 클래스의 래핑은 직렬화시 벗겨서 사용해야 한다.
- * 4. 원시 객체가 역직렬화시 원시 객체 래핑이 되어야 한다.
- * 5. 원시 래핑 클래스 인스턴스는 static, transient, native, volatile등이 modifier로 붙어 있으면 인식하지 않는다.
- * 6. 원시 래핑 클래스 인스턴스는 하나만 존재해야 하며 그 이상 존재하는 경우 오류를 출력한다.
- * 7. 인식할 수 있는 원시 객체 래핑 클래스 내부 변수 타입은 원시 타입, String, UUID 이다.
+ * 1. 날짜 데이터도 어노테이션 사용 없이 직렬화/역직렬화가 잘 동작해야 한다
+ * 2. 원시 래핑 클래스의 래핑은 직렬화시 벗겨서 사용해야 한다.
+ * 3. 원시 객체가 역직렬화시 원시 객체 래핑이 되어야 한다.
+ * 4. 원시 래핑 클래스 인스턴스는 static, transient, native, volatile등이 modifier로 붙어 있으면 인식하지 않는다.
+ * 5. 원시 래핑 클래스 인스턴스는 하나만 존재해야 하며 그 이상 존재하는 경우 오류를 출력한다.
+ * 6. 인식할 수 있는 원시 객체 래핑 클래스 내부 변수 타입은 원시 타입, String, UUID 이다.
  */
 @ExtendWith(SpringExtension.class)
 @Import({JacksonConfiguration.class})
@@ -47,22 +46,6 @@ class JacksonConfigurationTest {
 	static final Pattern DOUBLE = Pattern.compile("^[^0]\\d*\\.\\d*[^0]$");
 	@Autowired
 	ObjectMapper objectMapper;
-
-	@Test
-	@DisplayName("직렬화시 snake case형태의 json string으로 변환해야 함")
-	void shouldReturnSnakeCaseKeyNameWhenSerializeUsingObjectMapper() throws JsonProcessingException {
-		Dto dto = new Dto("hello", 10);
-		String value = objectMapper.writeValueAsString(dto);
-		assertThat(value).contains("user_name", "user_age");
-	}
-
-	@Test
-	@DisplayName("역직렬화시 snake case형태의 json string을 객체로 변환할 수 있어야 함")
-	void shouldReturnClassWhenDeSerializeSnakeCaseKeyJsonStringUsingObjectMapper() throws JsonProcessingException {
-		String input = "{\"user_name\":\"hello\",\"user_age\":10}";
-		Dto dto = objectMapper.readValue(input, Dto.class);
-		assertThat(dto).hasFieldOrPropertyWithValue("userName", "hello").hasFieldOrPropertyWithValue("userAge", 10);
-	}
 
 	@Test
 	@DisplayName("직렬화시 LocalDateTime이 어노테이션 없이 잘 동작해야 함")
@@ -76,7 +59,7 @@ class JacksonConfigurationTest {
 	@Test
 	@DisplayName("역직렬화시 입력이 ISO_LOCAL_DATE_TIME인 경우 잘 동작해야 함")
 	void shouldDeserializeWhenInputFormatIsISO_LOCAL_DATE_TIME() throws JsonProcessingException {
-		String jsonString = "{\"date_time\":\"2023-03-02T13:24:27.5431758\"}";
+		String jsonString = "{\"dateTime\":\"2023-03-02T13:24:27.5431758\"}";
 		DateForTest object = objectMapper.readValue(jsonString, DateForTest.class);
 		assertThat(object).hasFieldOrPropertyWithValue("dateTime",
 			LocalDateTime.parse("2023-03-02T13:24:27.5431758", DateTimeFormatter.ISO_LOCAL_DATE_TIME));
@@ -167,7 +150,7 @@ class JacksonConfigurationTest {
 
 	private boolean checkDateTimeFormat(String valueAsString) throws JSONException {
 		JSONObject jsonObject = new JSONObject(valueAsString);
-		String stringDate = jsonObject.getString("date_time");
+		String stringDate = jsonObject.getString("dateTime");
 		try {
 			LocalDate date = LocalDate.parse(stringDate, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
 			return true;

--- a/src/test/java/com/almondia/meca/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/almondia/meca/member/controller/MemberControllerTest.java
@@ -70,14 +70,14 @@ class MemberControllerTest {
 
 			mockMvc.perform(get("/api/v1/members/me"))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("member_id").exists())
+				.andExpect(jsonPath("memberId").exists())
 				.andExpect(jsonPath("name").exists())
 				.andExpect(jsonPath("email").exists())
-				.andExpect(jsonPath("oauth_type").exists())
+				.andExpect(jsonPath("oauthType").exists())
 				.andExpect(jsonPath("role").exists())
 				.andExpect(jsonPath("deleted").exists())
-				.andExpect(jsonPath("created_at").exists())
-				.andExpect(jsonPath("modified_at").exists());
+				.andExpect(jsonPath("createdAt").exists())
+				.andExpect(jsonPath("modifiedAt").exists());
 		}
 	}
 


### PR DESCRIPTION
## 요약

- jackson 모듈의 직/역직렬화 전략을 스네이크에서 카멜 케이스 으로 수정