### PR TITLE
feat/#56: 카드 히스토리 저장 API 구현

### DIFF
--- a/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepository.java
+++ b/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepository.java
@@ -1,12 +1,16 @@
 package com.almondia.meca.card.infra.querydsl;
 
 import java.util.List;
+import java.util.Map;
 
 import com.almondia.meca.card.domain.entity.Card;
+import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.common.infra.querydsl.SortOption;
 
 public interface CardQueryDslRepository {
 
 	List<Card> findCardByCategoryIdUsingCursorPaging(int pageSize,
 		CardSearchCriteria criteria, SortOption<CardSortField> sortOption);
+
+	Map<Id, List<Id>> findMapByListOfCardIdAndMemberId(List<Id> cardIds, Id memberId);
 }

--- a/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepositoryImpl.java
@@ -1,11 +1,14 @@
 package com.almondia.meca.card.infra.querydsl;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
 import com.almondia.meca.card.domain.entity.Card;
 import com.almondia.meca.card.domain.entity.QCard;
+import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.common.infra.querydsl.SortFactory;
 import com.almondia.meca.common.infra.querydsl.SortOption;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -30,5 +33,20 @@ public class CardQueryDslRepositoryImpl implements CardQueryDslRepository {
 			.orderBy(SortFactory.createOrderSpecifier(sortOption))
 			.limit(pageSize)
 			.fetch();
+	}
+
+	@Override
+	public Map<Id, List<Id>> findMapByListOfCardIdAndMemberId(List<Id> cardIds, Id memberId) {
+		return queryFactory
+			.select(card.cardId, card.categoryId)
+			.from(card)
+			.where(card.cardId.in(cardIds)
+				.and(card.memberId.eq(memberId)))
+			.fetch()
+			.stream()
+			.collect(Collectors.groupingBy(
+				tuple -> tuple.get(card.cardId),
+				Collectors.mapping(tuple -> tuple.get(card.categoryId), Collectors.toList())
+			));
 	}
 }

--- a/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
@@ -3,6 +3,7 @@ package com.almondia.meca.cardhistory.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
 import com.almondia.meca.cardhistory.service.CardHistoryService;
+import com.almondia.meca.member.domain.entity.Member;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,8 +24,10 @@ public class CardHistoryController {
 
 	@PostMapping("/simulation")
 	@Secured("ROLE_USER")
-	public ResponseEntity<String> saveHistories(@RequestBody SaveRequestCardHistoryDto saveRequestCardHistoryDto) {
-		cardHistoryService.saveHistories(saveRequestCardHistoryDto);
+	public ResponseEntity<String> saveHistories(
+		@AuthenticationPrincipal Member member,
+		@RequestBody SaveRequestCardHistoryDto saveRequestCardHistoryDto) {
+		cardHistoryService.saveHistories(saveRequestCardHistoryDto, member.getMemberId());
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
 }

--- a/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
@@ -1,0 +1,29 @@
+package com.almondia.meca.cardhistory.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
+import com.almondia.meca.cardhistory.service.CardHistoryService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/histories")
+@RequiredArgsConstructor
+public class CardHistoryController {
+
+	private final CardHistoryService cardHistoryService;
+
+	@PostMapping("/simulation")
+	@Secured("ROLE_USER")
+	public ResponseEntity<String> saveHistories(@RequestBody SaveRequestCardHistoryDto saveRequestCardHistoryDto) {
+		cardHistoryService.saveHistories(saveRequestCardHistoryDto);
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+}

--- a/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
@@ -28,6 +28,6 @@ public class CardHistoryController {
 		@AuthenticationPrincipal Member member,
 		@RequestBody SaveRequestCardHistoryDto saveRequestCardHistoryDto) {
 		cardHistoryService.saveHistories(saveRequestCardHistoryDto, member.getMemberId());
-		return ResponseEntity.status(HttpStatus.OK).build();
+		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 }

--- a/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryDto.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryDto.java
@@ -1,0 +1,24 @@
+package com.almondia.meca.cardhistory.controller.dto;
+
+import com.almondia.meca.cardhistory.domain.vo.Answer;
+import com.almondia.meca.cardhistory.domain.vo.Score;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+@AllArgsConstructor
+@ToString
+public class CardHistoryDto {
+
+	private Id cardId;
+	private Answer userAnswer;
+	private Score score;
+}

--- a/src/main/java/com/almondia/meca/cardhistory/controller/dto/SaveRequestCardHistoryDto.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/dto/SaveRequestCardHistoryDto.java
@@ -1,0 +1,19 @@
+package com.almondia.meca.cardhistory.controller.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@ToString
+public class SaveRequestCardHistoryDto {
+
+	private List<CardHistoryDto> cardHistoryDtos;
+
+}

--- a/src/main/java/com/almondia/meca/cardhistory/controller/dto/SaveRequestCardHistoryDto.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/dto/SaveRequestCardHistoryDto.java
@@ -14,6 +14,6 @@ import lombok.ToString;
 @ToString
 public class SaveRequestCardHistoryDto {
 
-	private List<CardHistoryDto> cardHistoryDtos;
+	private List<CardHistoryDto> cardHistories;
 
 }

--- a/src/main/java/com/almondia/meca/cardhistory/domain/repository/CardHistoryRepository.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/repository/CardHistoryRepository.java
@@ -1,0 +1,9 @@
+package com.almondia.meca.cardhistory.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.almondia.meca.cardhistory.domain.entity.CardHistory;
+import com.almondia.meca.common.domain.vo.Id;
+
+public interface CardHistoryRepository extends JpaRepository<CardHistory, Id> {
+}

--- a/src/main/java/com/almondia/meca/cardhistory/service/CardHistoryService.java
+++ b/src/main/java/com/almondia/meca/cardhistory/service/CardHistoryService.java
@@ -1,0 +1,21 @@
+package com.almondia.meca.cardhistory.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
+import com.almondia.meca.cardhistory.domain.repository.CardHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CardHistoryService {
+
+	private final CardHistoryRepository cardHistoryRepository;
+
+	@Transactional
+	public void saveHistories(SaveRequestCardHistoryDto saveRequestCardHistoryDto) {
+
+	}
+}

--- a/src/main/java/com/almondia/meca/cardhistory/service/CardHistoryService.java
+++ b/src/main/java/com/almondia/meca/cardhistory/service/CardHistoryService.java
@@ -1,19 +1,20 @@
 package com.almondia.meca.cardhistory.service;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.almondia.meca.card.domain.entity.Card;
-import com.almondia.meca.card.repository.CardRepository;
-import com.almondia.meca.card.sevice.checker.CardChecker;
+import com.almondia.meca.card.domain.repository.CardRepository;
 import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
 import com.almondia.meca.cardhistory.domain.entity.CardHistory;
 import com.almondia.meca.cardhistory.domain.repository.CardHistoryRepository;
-import com.almondia.meca.cardhistory.service.helper.CardHistoryFactory;
+import com.almondia.meca.common.domain.vo.Id;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,16 +24,39 @@ public class CardHistoryService {
 
 	private final CardHistoryRepository cardHistoryRepository;
 	private final CardRepository cardRepository;
-	private final CardChecker cardChecker;
 
 	@Transactional
-	public void saveHistories(SaveRequestCardHistoryDto saveRequestCardHistoryDto) {
+	public void saveHistories(SaveRequestCardHistoryDto saveRequestCardHistoryDto, Id memberId) {
+		Map<Id, List<Id>> categoryIdsByCardId = checkAuthority(saveRequestCardHistoryDto, memberId);
+		List<CardHistory> cardHistories = getCardHistories(saveRequestCardHistoryDto, categoryIdsByCardId);
+		cardHistoryRepository.saveAll(cardHistories);
+	}
+
+	private List<CardHistory> getCardHistories(SaveRequestCardHistoryDto saveRequestCardHistoryDto,
+		Map<Id, List<Id>> categoryIdsByCardId) {
 		List<CardHistory> cardHistories = new ArrayList<>();
 		for (CardHistoryDto cardHistoryDto : saveRequestCardHistoryDto.getCardHistoryDtos()) {
-			Card card = cardRepository.findById(cardHistoryDto.getCardId())
-				.orElseThrow(() -> new IllegalArgumentException("해당 카드가 존재하지 않습니다"));
-			cardHistories.add(CardHistoryFactory.makeCardHistory(cardHistoryDto, card.getCategoryId()));
+			CardHistory cardHistory = CardHistory.builder()
+				.cardHistoryId(Id.generateNextId())
+				.cardId(cardHistoryDto.getCardId())
+				.categoryId(categoryIdsByCardId.get(cardHistoryDto.getCardId()).get(0))
+				.userAnswer(cardHistoryDto.getUserAnswer())
+				.score(cardHistoryDto.getScore())
+				.build();
+			cardHistories.add(cardHistory);
 		}
-		cardHistoryRepository.saveAll(cardHistories);
+		return cardHistories;
+	}
+
+	private Map<Id, List<Id>> checkAuthority(SaveRequestCardHistoryDto saveRequestCardHistoryDto, Id memberId) {
+		List<Id> cardIds = saveRequestCardHistoryDto.getCardHistoryDtos().stream()
+			.map(CardHistoryDto::getCardId)
+			.collect(Collectors.toList());
+		Map<Id, List<Id>> categoryIdsByCardId = cardRepository.findMapByListOfCardIdAndMemberId(cardIds, memberId);
+		long allValuesCount = categoryIdsByCardId.values().stream().mapToLong(Collection::size).sum();
+		if (allValuesCount != cardIds.size()) {
+			throw new IllegalArgumentException("권한이 없거나 옳바르지 않은 입력을 하셨습니다");
+		}
+		return categoryIdsByCardId;
 	}
 }

--- a/src/main/java/com/almondia/meca/cardhistory/service/CardHistoryService.java
+++ b/src/main/java/com/almondia/meca/cardhistory/service/CardHistoryService.java
@@ -35,7 +35,7 @@ public class CardHistoryService {
 	private List<CardHistory> getCardHistories(SaveRequestCardHistoryDto saveRequestCardHistoryDto,
 		Map<Id, List<Id>> categoryIdsByCardId) {
 		List<CardHistory> cardHistories = new ArrayList<>();
-		for (CardHistoryDto cardHistoryDto : saveRequestCardHistoryDto.getCardHistoryDtos()) {
+		for (CardHistoryDto cardHistoryDto : saveRequestCardHistoryDto.getCardHistories()) {
 			CardHistory cardHistory = CardHistory.builder()
 				.cardHistoryId(Id.generateNextId())
 				.cardId(cardHistoryDto.getCardId())
@@ -49,7 +49,7 @@ public class CardHistoryService {
 	}
 
 	private Map<Id, List<Id>> checkAuthority(SaveRequestCardHistoryDto saveRequestCardHistoryDto, Id memberId) {
-		List<Id> cardIds = saveRequestCardHistoryDto.getCardHistoryDtos().stream()
+		List<Id> cardIds = saveRequestCardHistoryDto.getCardHistories().stream()
 			.map(CardHistoryDto::getCardId)
 			.collect(Collectors.toList());
 		Map<Id, List<Id>> categoryIdsByCardId = cardRepository.findMapByListOfCardIdAndMemberId(cardIds, memberId);

--- a/src/main/java/com/almondia/meca/cardhistory/service/CardHistoryService.java
+++ b/src/main/java/com/almondia/meca/cardhistory/service/CardHistoryService.java
@@ -1,10 +1,19 @@
 package com.almondia.meca.cardhistory.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.almondia.meca.card.domain.entity.Card;
+import com.almondia.meca.card.repository.CardRepository;
+import com.almondia.meca.card.sevice.checker.CardChecker;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
+import com.almondia.meca.cardhistory.domain.entity.CardHistory;
 import com.almondia.meca.cardhistory.domain.repository.CardHistoryRepository;
+import com.almondia.meca.cardhistory.service.helper.CardHistoryFactory;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,9 +22,17 @@ import lombok.RequiredArgsConstructor;
 public class CardHistoryService {
 
 	private final CardHistoryRepository cardHistoryRepository;
+	private final CardRepository cardRepository;
+	private final CardChecker cardChecker;
 
 	@Transactional
 	public void saveHistories(SaveRequestCardHistoryDto saveRequestCardHistoryDto) {
-
+		List<CardHistory> cardHistories = new ArrayList<>();
+		for (CardHistoryDto cardHistoryDto : saveRequestCardHistoryDto.getCardHistoryDtos()) {
+			Card card = cardRepository.findById(cardHistoryDto.getCardId())
+				.orElseThrow(() -> new IllegalArgumentException("해당 카드가 존재하지 않습니다"));
+			cardHistories.add(CardHistoryFactory.makeCardHistory(cardHistoryDto, card.getCategoryId()));
+		}
+		cardHistoryRepository.saveAll(cardHistories);
 	}
 }

--- a/src/main/java/com/almondia/meca/cardhistory/service/helper/CardHistoryFactory.java
+++ b/src/main/java/com/almondia/meca/cardhistory/service/helper/CardHistoryFactory.java
@@ -1,0 +1,18 @@
+package com.almondia.meca.cardhistory.service.helper;
+
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.domain.entity.CardHistory;
+import com.almondia.meca.common.domain.vo.Id;
+
+public class CardHistoryFactory {
+
+	public static CardHistory makeCardHistory(CardHistoryDto cardHistoryDto, Id categoryId) {
+		return CardHistory.builder()
+			.cardHistoryId(Id.generateNextId())
+			.cardId(cardHistoryDto.getCardId())
+			.categoryId(categoryId)
+			.userAnswer(cardHistoryDto.getUserAnswer())
+			.score(cardHistoryDto.getScore())
+			.build();
+	}
+}

--- a/src/test/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepositoryImplTest.java
@@ -3,8 +3,10 @@ package com.almondia.meca.card.infra.querydsl;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -128,5 +130,18 @@ class CardQueryDslRepositoryImplTest {
 				SortOrder.DESC));
 		assertThat(paging.get(0).getCreatedAt()).isEqualTo(time);
 		assertThat(paging).hasSize(2);
+	}
+
+	@Test
+	@DisplayName("aa")
+	void shouldReturnMapWhenCallFindCardByListOfCardIdTest() {
+		List<Card> cards = cardRepository.findAll();
+		List<Id> cardIds = List.of(cards.get(0).getCardId(), cards.get(1).getCardId(), cards.get(2).getCardId());
+		Map<Id, List<Id>> fetch = cardRepository.findMapByListOfCardIdAndMemberId(cardIds, memberId);
+		long sum = fetch.values()
+			.stream()
+			.mapToLong(Collection::size)
+			.sum();
+		assertThat(sum).isEqualTo(3);
 	}
 }

--- a/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
@@ -1,0 +1,83 @@
+package com.almondia.meca.cardhistory.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
+import com.almondia.meca.cardhistory.domain.vo.Answer;
+import com.almondia.meca.cardhistory.domain.vo.Score;
+import com.almondia.meca.cardhistory.service.CardHistoryService;
+import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
+import com.almondia.meca.common.configuration.security.filter.JwtAuthenticationFilter;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.mock.security.WithMockMember;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(CardHistoryController.class)
+@Import({JacksonConfiguration.class})
+class CardHistoryControllerTest {
+
+	@MockBean
+	CardHistoryService cardHistoryService;
+
+	@MockBean
+	JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Autowired
+	WebApplicationContext context;
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@BeforeEach
+	void before() {
+		mockMvc = MockMvcBuilders.webAppContextSetup(context).alwaysDo(print()).build();
+	}
+
+	/**
+	 * 1. 정상 응답 테스트
+	 */
+	@Nested
+	@DisplayName("시뮬레이션 결과 저장 API")
+	class SaveSimulationCardHistoryTest {
+
+		@Test
+		@DisplayName("정상 응답 테스트")
+		@WithMockMember
+		void shouldReturn200WhenSuccessTest() throws Exception {
+			CardHistoryDto historyDto = CardHistoryDto.builder()
+				.cardId(Id.generateNextId())
+				.userAnswer(new Answer("answer"))
+				.score(new Score(100))
+				.build();
+			SaveRequestCardHistoryDto saveRequestCardHistoryDto = new SaveRequestCardHistoryDto(List.of(historyDto));
+
+			mockMvc.perform(post("/api/v1/histories/simulation")
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8)
+					.content(objectMapper.writeValueAsString(saveRequestCardHistoryDto)))
+				.andExpect(status().isOk());
+		}
+	}
+}

--- a/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
@@ -77,7 +77,7 @@ class CardHistoryControllerTest {
 					.contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8)
 					.content(objectMapper.writeValueAsString(saveRequestCardHistoryDto)))
-				.andExpect(status().isOk());
+				.andExpect(status().isCreated());
 		}
 	}
 }

--- a/src/test/java/com/almondia/meca/cardhistory/service/CardHistoryServiceTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/service/CardHistoryServiceTest.java
@@ -1,5 +1,61 @@
 package com.almondia.meca.cardhistory.service;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.almondia.meca.card.domain.entity.Card;
+import com.almondia.meca.card.domain.repository.CardRepository;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
+import com.almondia.meca.cardhistory.domain.vo.Answer;
+import com.almondia.meca.cardhistory.domain.vo.Score;
+import com.almondia.meca.common.configuration.jpa.JpaAuditingConfiguration;
+import com.almondia.meca.common.configuration.jpa.QueryDslConfiguration;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.data.CardDataFactory;
+
+/**
+ * 1. 권한 체크 여부 테스트
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfiguration.class, QueryDslConfiguration.class, CardHistoryService.class})
 class CardHistoryServiceTest {
 
+	@Autowired
+	CardRepository cardRepository;
+
+	@Autowired
+	CardHistoryService cardHistoryService;
+
+	CardDataFactory cardDataFactory = new CardDataFactory();
+
+	@BeforeEach
+	void before() {
+		List<Card> testData = cardDataFactory.createTestData();
+		cardRepository.saveAll(testData);
+	}
+
+	@Test
+	@DisplayName("권한 체크 여부 테스트")
+	void checkAuthorityTest() {
+		SaveRequestCardHistoryDto saveRequestCardHistoryDto = new SaveRequestCardHistoryDto(List.of(
+			CardHistoryDto.builder()
+				.cardId(Id.generateNextId())
+				.score(new Score(100))
+				.userAnswer(new Answer("100"))
+				.build()));
+		assertThatThrownBy(
+			() -> cardHistoryService.saveHistories(saveRequestCardHistoryDto, Id.generateNextId())).isInstanceOf(
+			IllegalArgumentException.class);
+	}
 }

--- a/src/test/java/com/almondia/meca/cardhistory/service/CardHistoryServiceTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/service/CardHistoryServiceTest.java
@@ -1,0 +1,5 @@
+package com.almondia.meca.cardhistory.service;
+
+class CardHistoryServiceTest {
+
+}

--- a/src/test/java/com/almondia/meca/cardhistory/service/helper/CardHistoryFactoryTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/service/helper/CardHistoryFactoryTest.java
@@ -1,0 +1,36 @@
+package com.almondia.meca.cardhistory.service.helper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.domain.entity.CardHistory;
+import com.almondia.meca.cardhistory.domain.vo.Answer;
+import com.almondia.meca.cardhistory.domain.vo.Score;
+import com.almondia.meca.common.domain.vo.Id;
+
+/**
+ * dto로부터 정상정인 인스턴스 생성하는지 테스트
+ */
+class CardHistoryFactoryTest {
+
+	@Test
+	@DisplayName("dto에서 정상정인 인스턴스 생성하는지 테스트")
+	void shouldGenerateNewInstanceFromDtoTest() {
+		CardHistoryDto cardHistoryDto = CardHistoryDto.builder()
+			.cardId(Id.generateNextId())
+			.score(new Score(100))
+			.userAnswer(new Answer("123"))
+			.build();
+		Id categoryId = Id.generateNextId();
+		CardHistory cardHistory = CardHistoryFactory.makeCardHistory(cardHistoryDto, categoryId);
+		assertThat(cardHistory)
+			.hasFieldOrPropertyWithValue("cardId", cardHistoryDto.getCardId())
+			.hasFieldOrPropertyWithValue("score", cardHistoryDto.getScore())
+			.hasFieldOrPropertyWithValue("userAnswer", cardHistoryDto.getUserAnswer())
+			.hasFieldOrPropertyWithValue("categoryId", categoryId);
+
+	}
+}


### PR DESCRIPTION
## 요약

- 시뮬레이션 이후 채점 결과에 대한 카드 히스토리 저장 API 구현
- 각 카드들이 개인이 접근할 권한이 있는지 체크
- 저장 성공 시 201 반환