### PR TITLE
feat/#51: 카드 삭제 api 추가

### DIFF
--- a/src/main/java/com/almondia/meca/card/controller/CardController.java
+++ b/src/main/java/com/almondia/meca/card/controller/CardController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -68,6 +69,16 @@ public class CardController {
 		CursorPage<CardResponseDto> responseDto = cardService.searchCursorPagingCard(pageSize, categoryId, criteria,
 			SortOption.of(CardSortField.CARD_ID, sortOrder), member.getMemberId());
 		return ResponseEntity.ok(responseDto);
+	}
+
+	@Secured("ROLE_USER")
+	@DeleteMapping("/{cardId}")
+	public ResponseEntity<String> deleteCard(
+		@AuthenticationPrincipal Member member,
+		@PathVariable(value = "cardId") Id cardId
+	) {
+		cardService.deleteCard(cardId, member.getMemberId());
+		return ResponseEntity.status(HttpStatus.OK).body("");
 	}
 
 	private CardSearchCriteria makeCursorCriteria(Id categoryId, Id lastId,

--- a/src/main/java/com/almondia/meca/card/sevice/CardService.java
+++ b/src/main/java/com/almondia/meca/card/sevice/CardService.java
@@ -21,6 +21,8 @@ import com.almondia.meca.card.infra.querydsl.CardSortField;
 import com.almondia.meca.card.sevice.checker.CardChecker;
 import com.almondia.meca.card.sevice.helper.CardFactory;
 import com.almondia.meca.card.sevice.helper.CardMapper;
+import com.almondia.meca.cardhistory.domain.entity.CardHistory;
+import com.almondia.meca.cardhistory.domain.repository.CardHistoryRepository;
 import com.almondia.meca.category.service.checker.CategoryChecker;
 import com.almondia.meca.common.controller.dto.CursorPage;
 import com.almondia.meca.common.domain.vo.Id;
@@ -32,6 +34,7 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class CardService {
 
+	private final CardHistoryRepository cardHistoryRepository;
 	private final CardRepository cardRepository;
 	private final OxCardRepository oxCardRepository;
 	private final KeywordCardRepository keywordCardRepository;
@@ -76,6 +79,14 @@ public class CardService {
 		List<Card> cursor = cardRepository.findCardByCategoryIdUsingCursorPaging(pageSize,
 			cardSearchCriteria, sortOption);
 		return CardMapper.cardsToCursorPagingDto(cursor, pageSize, sortOption.getSortOrder());
+	}
+
+	@Transactional
+	public void deleteCard(Id cardId, Id memberId) {
+		Card card = cardChecker.checkAuthority(cardId, memberId);
+		card.delete();
+		List<CardHistory> cardHistories = cardHistoryRepository.findByCardId(cardId);
+		cardHistories.forEach(CardHistory::delete);
 	}
 
 	private void updateCard(UpdateCardRequestDto updateCardRequestDto, Id memberId, Card card) {

--- a/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
@@ -34,24 +34,25 @@ public class CardHistory {
 
 	@EmbeddedId
 	@AttributeOverride(name = "uuid", column = @Column(name = "card_history_id", nullable = false, columnDefinition = "BINARY(16)"))
-	Id cardHistoryId;
+	private Id cardHistoryId;
 
 	@Embedded
 	@AttributeOverride(name = "uuid", column = @Column(name = "card_id", nullable = false, columnDefinition = "BINARY(16)"))
-	Id cardId;
+	private Id cardId;
 
 	@Embedded
 	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, columnDefinition = "BINARY(16)"))
-	Id categoryId;
+	private Id categoryId;
 
 	@Embedded
 	@AttributeOverride(name = "answer", column = @Column(name = "user_answer", nullable = false, length = 25))
-	Answer userAnswer;
+	private Answer userAnswer;
 
 	@Embedded
 	@AttributeOverride(name = "score", column = @Column(name = "score", nullable = false))
-	Score score;
+	private Score score;
 
 	@CreatedDate
-	LocalDateTime createdAt;
+	private LocalDateTime createdAt;
+
 }

--- a/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
@@ -52,7 +52,17 @@ public class CardHistory {
 	@AttributeOverride(name = "score", column = @Column(name = "score", nullable = false))
 	private Score score;
 
+	private boolean isDeleted;
+
 	@CreatedDate
 	private LocalDateTime createdAt;
+
+	public void delete() {
+		isDeleted = true;
+	}
+
+	public void rollback() {
+		isDeleted = false;
+	}
 
 }

--- a/src/main/java/com/almondia/meca/cardhistory/domain/repository/CardHistoryRepository.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/repository/CardHistoryRepository.java
@@ -1,9 +1,12 @@
 package com.almondia.meca.cardhistory.domain.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.almondia.meca.cardhistory.domain.entity.CardHistory;
 import com.almondia.meca.common.domain.vo.Id;
 
 public interface CardHistoryRepository extends JpaRepository<CardHistory, Id> {
+	List<CardHistory> findByCardId(Id cardId);
 }

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -207,4 +207,20 @@ class CardControllerTest {
 				.build();
 		}
 	}
+
+	/**
+	 * 1. 정상 동작시 200 응답 테스트
+	 */
+	@Nested
+	@DisplayName("카드 삭제 API")
+	class DeleteCardTest {
+
+		@Test
+		@DisplayName("정상 동작시 200 응답 테스트")
+		@WithMockMember
+		void shouldReturnOkWhenCallSuccessTest() throws Exception {
+			mockMvc.perform(delete("/api/v1/cards/{cardId}", Id.generateNextId()))
+				.andExpect(status().isOk());
+		}
+	}
 }

--- a/src/test/java/com/almondia/meca/card/sevice/CardServiceTest.java
+++ b/src/test/java/com/almondia/meca/card/sevice/CardServiceTest.java
@@ -243,4 +243,19 @@ class CardServiceTest {
 				.hasFieldOrProperty("sortOrder");
 		}
 	}
+
+	/**
+	 * 1. 권한 체크를 수행하는지 테스트
+	 */
+	@Nested
+	@DisplayName("카드 삭제")
+	class CardDeleteTest {
+
+		@Test
+		@DisplayName("권한 체크를 수행하는지 테스트")
+		void checkAuthorityTest() {
+			assertThatThrownBy(() -> cardService.deleteCard(Id.generateNextId(), Id.generateNextId())).isInstanceOf(
+				AccessDeniedException.class);
+		}
+	}
 }

--- a/src/test/java/com/almondia/meca/cardhistory/domain/entity/CardHistoryTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/domain/entity/CardHistoryTest.java
@@ -22,6 +22,8 @@ import com.almondia.meca.common.domain.vo.Id;
 
 /**
  * 1. 데이터 속성 생성 테스트
+ * 2. delete 수행시 isDeleted = true
+ * 3. rollbeck 수행시 isDeleted = false
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -38,7 +40,8 @@ class CardHistoryTest {
 		assertThat(entityType).isNotNull();
 		assertThat(entityType.getName()).isEqualTo("CardHistory");
 		assertThat(entityType.getAttributes()).extracting("name")
-			.containsExactlyInAnyOrder("categoryId", "cardId", "cardHistoryId", "score", "userAnswer", "createdAt");
+			.containsExactlyInAnyOrder("isDeleted", "categoryId", "cardId", "cardHistoryId", "score", "userAnswer",
+				"createdAt");
 	}
 
 	@Test
@@ -55,4 +58,34 @@ class CardHistoryTest {
 		LocalDateTime createdAt = cardHistory.getCreatedAt();
 		assertThat(createdAt).isNotNull();
 	}
+
+	@Test
+	@DisplayName("delete 수행시 isDeleted = true")
+	void shouldChangeTrueWhenCallDeleteTest() {
+		CardHistory cardHistory = CardHistory.builder()
+			.cardHistoryId(Id.generateNextId())
+			.cardId(Id.generateNextId())
+			.categoryId(Id.generateNextId())
+			.score(new Score(100))
+			.userAnswer(new Answer("answer"))
+			.build();
+		cardHistory.delete();
+		assertThat(cardHistory).hasFieldOrPropertyWithValue("isDeleted", true);
+	}
+
+	@Test
+	@DisplayName("rollbeck 수행시 isDeleted = false")
+	void shouldChangeFalseWhenCallRollbackTest() {
+		CardHistory cardHistory = CardHistory.builder()
+			.cardHistoryId(Id.generateNextId())
+			.cardId(Id.generateNextId())
+			.categoryId(Id.generateNextId())
+			.score(new Score(100))
+			.userAnswer(new Answer("answer"))
+			.isDeleted(false)
+			.build();
+		cardHistory.rollback();
+		assertThat(cardHistory).hasFieldOrPropertyWithValue("isDeleted", false);
+	}
+
 }


### PR DESCRIPTION
## 요약

- 카드 삭제 시 isDeleted 상태가 true가 됨
- 카드 삭제 시 카드와 카드 관련 히스토리 모두 삭제