### PR TITLE
fix/#27: kakao email이 없어서 발생하는 500 문제 해결

### DIFF
--- a/src/main/java/com/almondia/meca/auth/oauth/infra/attribute/OAuth2UserAttribute.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/infra/attribute/OAuth2UserAttribute.java
@@ -11,11 +11,12 @@ import lombok.ToString;
 @ToString
 public class OAuth2UserAttribute {
 
+	private final String oAuthId;
 	private final String name;
 	private final String email;
 	private final OAuthType oauthType;
 
-	public static OAuth2UserAttribute of(String name, String email, OAuthType oauthType) {
-		return new OAuth2UserAttribute(name, email, oauthType);
+	public static OAuth2UserAttribute of(String oAuthId, String name, String email, OAuthType oauthType) {
+		return new OAuth2UserAttribute(oAuthId, name, email, oauthType);
 	}
 }

--- a/src/main/java/com/almondia/meca/auth/oauth/service/UserInfoExtractor.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/service/UserInfoExtractor.java
@@ -14,9 +14,13 @@ public enum UserInfoExtractor {
 		public OAuth2UserAttribute extract(Map<String, Object> userInfoJson) {
 			JSONObject userInfo = new JSONObject(userInfoJson);
 			JSONObject response = userInfo.getJSONObject("response");
+			String oAuthId = response.getString("id");
 			String name = response.getString("name");
-			String email = response.getString("email");
-			return OAuth2UserAttribute.of(name, email, OAuthType.NAVER);
+			String email = null;
+			if (response.has("email")) {
+				email = response.getString("email");
+			}
+			return OAuth2UserAttribute.of(oAuthId, name, email, OAuthType.NAVER);
 		}
 	},
 	KAKAO("kakao") {
@@ -25,18 +29,26 @@ public enum UserInfoExtractor {
 			JSONObject userInfo = new JSONObject(userInfoJson);
 			JSONObject properties = userInfo.getJSONObject("properties");
 			JSONObject kakaoAccount = userInfo.getJSONObject("kakao_account");
+			String oAuthId = String.valueOf(userInfoJson.get("id"));
 			String name = properties.getString("nickname");
-			String email = kakaoAccount.getString("email");
-			return OAuth2UserAttribute.of(name, email, OAuthType.KAKAO);
+			String email = null;
+			if (kakaoAccount.has("email")) {
+				email = kakaoAccount.getString("email");
+			}
+			return OAuth2UserAttribute.of(oAuthId, name, email, OAuthType.KAKAO);
 		}
 	},
 	GOOGLE("google") {
 		@Override
 		public OAuth2UserAttribute extract(Map<String, Object> userInfoJson) {
 			JSONObject userInfo = new JSONObject(userInfoJson);
-			String email = userInfo.getString("email");
+			String oAuthId = userInfo.getString("sub");
+			String email = null;
+			if (userInfo.has("email")) {
+				email = userInfo.getString("email");
+			}
 			String name = userInfo.getString("name");
-			return OAuth2UserAttribute.of(name, email, OAuthType.GOOGLE);
+			return OAuth2UserAttribute.of(oAuthId, name, email, OAuthType.GOOGLE);
 		}
 	};
 

--- a/src/main/java/com/almondia/meca/member/domain/entity/Member.java
+++ b/src/main/java/com/almondia/meca/member/domain/entity/Member.java
@@ -38,7 +38,7 @@ public class Member extends DateEntity {
 	private Name name;
 
 	@Embedded
-	@AttributeOverride(name = "email", column = @Column(name = "email", nullable = false, columnDefinition = "VARCHAR(255)"))
+	@AttributeOverride(name = "email", column = @Column(name = "email", columnDefinition = "VARCHAR(255)"))
 	private Email email;
 
 	@Column(name = "o_auth_type", nullable = false, columnDefinition = "VARCHAR(10)")

--- a/src/main/java/com/almondia/meca/member/domain/entity/Member.java
+++ b/src/main/java/com/almondia/meca/member/domain/entity/Member.java
@@ -30,6 +30,9 @@ public class Member extends DateEntity {
 	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, columnDefinition = "BINARY(16)"))
 	private Id memberId;
 
+	@Column(name = "oauth_id", nullable = false, length = 40, unique = true)
+	private String oAuthId;
+
 	@Embedded
 	@AttributeOverride(name = "name", column = @Column(name = "name", nullable = false, columnDefinition = "VARCHAR(40)"))
 	private Name name;

--- a/src/main/java/com/almondia/meca/member/domain/vo/Name.java
+++ b/src/main/java/com/almondia/meca/member/domain/vo/Name.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Name implements Wrapper {
 
-	private static final Pattern NAME_PATTERN = Pattern.compile("^[a-zA-Z가-힣]{1,20}$");
+	private static final Pattern NAME_PATTERN = Pattern.compile("^[a-zA-Z가-힣\\s]{1,20}$");
 	private String name;
 
 	public Name(String name) {
@@ -25,6 +25,10 @@ public class Name implements Wrapper {
 	}
 
 	private void validateNameFormat(String name) {
+		name = name.strip();
+		if (name.isBlank()) {
+			throw new IllegalArgumentException("빈 공백을 입력할 수 없습니다");
+		}
 		Matcher matcher = NAME_PATTERN.matcher(name);
 		if (!matcher.find()) {
 			throw new IllegalArgumentException("이름은 영문 또는 한글 1 ~ 20 사이만 입력 가능합니다");

--- a/src/main/java/com/almondia/meca/member/service/MemberService.java
+++ b/src/main/java/com/almondia/meca/member/service/MemberService.java
@@ -22,11 +22,13 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 
 	public Member save(OAuth2UserAttribute oauth2UserAttribute) {
+		Email email = oauth2UserAttribute.getEmail() == null ? null : new Email(oauth2UserAttribute.getEmail());
 		Member member = Member.builder()
 			.memberId(Id.generateNextId())
+			.oAuthId(oauth2UserAttribute.getOAuthId())
 			.name(new Name(oauth2UserAttribute.getName()))
 			.oAuthType(oauth2UserAttribute.getOauthType())
-			.email(new Email(oauth2UserAttribute.getEmail()))
+			.email(email)
 			.role(Role.USER)
 			.build();
 		memberRepository.save(member);

--- a/src/test/java/com/almondia/meca/auth/AuthControllerTest.java
+++ b/src/test/java/com/almondia/meca/auth/AuthControllerTest.java
@@ -49,10 +49,10 @@ class AuthControllerTest {
 	Oauth2Service oauth2Service;
 
 	@Test
-	@DisplayName("요청 성공시 AccessTokenResponseDto 속성에 담긴 값이 모두 출력되야 하며 snakeCase여야 함 성공 응답은 200")
+	@DisplayName("요청 성공시 AccessTokenResponseDto 속성에 담긴 값이 모두 출력되야 하며 camel case여야 함 성공 응답은 200")
 	void shouldReturnAccessTokenResponseDtoAllPropertiesAndResponseStatusUsingSnakeCaseTest() throws Exception {
 		Mockito.doReturn(Member.builder().memberId(Id.generateNextId()).build()).when(memberService).save(any());
-		Mockito.doReturn(OAuth2UserAttribute.of("hello", "hello@naver.com", OAuthType.GOOGLE))
+		Mockito.doReturn(OAuth2UserAttribute.of("id", "hello", "hello@naver.com", OAuthType.GOOGLE))
 			.when(oauth2Service)
 			.requestUserInfo(eq("kakao"), anyString());
 		Mockito.doReturn("access token").when(jwtTokenService).createToken(any());

--- a/src/test/java/com/almondia/meca/member/domain/entity/MemberTest.java
+++ b/src/test/java/com/almondia/meca/member/domain/entity/MemberTest.java
@@ -45,7 +45,7 @@ class MemberTest {
 		assertThat(entityType).isNotNull();
 		assertThat(entityType.getName()).isEqualTo("Member");
 		assertThat(entityType.getAttributes()).extracting("name")
-			.containsExactlyInAnyOrder("memberId", "name", "email", "oAuthType", "createdAt", "modifiedAt",
+			.containsExactlyInAnyOrder("oAuthId", "memberId", "name", "email", "oAuthType", "createdAt", "modifiedAt",
 				"role", "isDeleted");
 	}
 
@@ -55,6 +55,7 @@ class MemberTest {
 		JpaRepository<Member, Id> memberRepository = new SimpleJpaRepository<>(Member.class, entityManager);
 		Member member = Member.builder()
 			.memberId(Id.generateNextId())
+			.oAuthId("id")
 			.email(new Email("hello@naver.com"))
 			.name(new Name("hello"))
 			.oAuthType(OAuthType.GOOGLE)

--- a/src/test/java/com/almondia/meca/member/domain/vo/NameTest.java
+++ b/src/test/java/com/almondia/meca/member/domain/vo/NameTest.java
@@ -10,14 +10,21 @@ import org.junit.jupiter.params.provider.CsvSource;
 /**
  * 1. toString 시 내부 객체의 정보를 보여준다.
  * 2. 영문자, 또는 한글 1 ~ 20까지 허용한다.
+ * 3. 빈 공백을 입력으로 할 수 없다.
  */
 class NameTest {
 
 	@Test
+	@DisplayName("빈 공백을 입력으로 할 수 없다")
+	void shouldNotBlankTest() {
+		assertThatThrownBy(() -> new Name("  ")).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
 	@DisplayName("toString과 내부 객체 정보 일치")
 	void shouldReturnIntervalValueWhenToString() {
-		Name name = new Name("최번개");
-		assertThat(name.toString()).isEqualTo("최번개");
+		Name name = new Name("최 번개");
+		assertThat(name.toString()).isEqualTo("최 번개");
 	}
 
 	@ParameterizedTest

--- a/src/test/java/com/almondia/meca/member/service/MemberServiceTest.java
+++ b/src/test/java/com/almondia/meca/member/service/MemberServiceTest.java
@@ -43,7 +43,7 @@ class MemberServiceTest {
 	@Test
 	@DisplayName("save 요청시 oauth2UserAttribute 정보가 db에 저장된다")
 	void shouldSaveDbTestWhenCallSaveOAuthAttributeTest() {
-		OAuth2UserAttribute oAuth2UserAttribute = new OAuth2UserAttribute("hello", "marrin1101@naver.com",
+		OAuth2UserAttribute oAuth2UserAttribute = new OAuth2UserAttribute("id", "hello", "marrin1101@naver.com",
 			OAuthType.NAVER);
 		memberService.save(oAuth2UserAttribute);
 		List<Member> all = memberRepository.findAll();

--- a/src/test/java/com/almondia/meca/member/service/MemberServiceTest.java
+++ b/src/test/java/com/almondia/meca/member/service/MemberServiceTest.java
@@ -63,6 +63,7 @@ class MemberServiceTest {
 		Id id = Id.generateNextId();
 		Member member = Member.builder()
 			.memberId(id)
+			.oAuthId("id")
 			.oAuthType(OAuthType.KAKAO)
 			.name(new Name("hello"))
 			.email(new Email("hello@naver.com"))
@@ -83,6 +84,7 @@ class MemberServiceTest {
 		Id id = Id.generateNextId();
 		Member member = Member.builder()
 			.memberId(id)
+			.oAuthId("id")
 			.oAuthType(OAuthType.KAKAO)
 			.name(new Name("hello"))
 			.email(new Email("hello@naver.com"))


### PR DESCRIPTION
## 요약

세부 사항:
- email의 경우 필수 사항이 아니기 때문에 없는 키를 체크하고 없으면 null 허용
- oAuth 회원들의 고유값을 위해서 OAuth Id 를 받아옴
- Member에 OAuthId 속성 추가(고유값, 회원 식별용)