### PR TITLE
fix/#48:  중복 로그인시 매번 회원 생성 문제 해결

### DIFF
--- a/src/main/java/com/almondia/meca/auth/AuthController.java
+++ b/src/main/java/com/almondia/meca/auth/AuthController.java
@@ -1,5 +1,6 @@
 package com.almondia.meca.auth;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,11 +32,15 @@ public class AuthController {
 	public ResponseEntity<AccessTokenResponseDto> getUserInfo(
 		@PathVariable("registrationId") String registrationId,
 		@RequestParam("code") String authorizationCode) {
-
+		HttpStatus statusResponse = HttpStatus.OK;
 		OAuth2UserAttribute oauth2UserAttribute = oauth2Service.requestUserInfo(registrationId,
 			authorizationCode);
-		Member member = memberService.save(oauth2UserAttribute);
+		Member member = memberService.findMemberByOAuthId(oauth2UserAttribute.getOAuthId());
+		if (member == null) {
+			member = memberService.save(oauth2UserAttribute);
+			statusResponse = HttpStatus.CREATED;
+		}
 		String accessToken = jwtTokenService.createToken(member.getMemberId());
-		return ResponseEntity.ok(AccessTokenResponseDto.of(accessToken));
+		return ResponseEntity.status(statusResponse).body(AccessTokenResponseDto.of(accessToken));
 	}
 }

--- a/src/main/java/com/almondia/meca/member/domain/entity/Member.java
+++ b/src/main/java/com/almondia/meca/member/domain/entity/Member.java
@@ -31,7 +31,7 @@ public class Member extends DateEntity {
 	private Id memberId;
 
 	@Column(name = "oauth_id", nullable = false, length = 40, unique = true)
-	private String oAuthId;
+	private String oauthId;
 
 	@Embedded
 	@AttributeOverride(name = "name", column = @Column(name = "name", nullable = false, columnDefinition = "VARCHAR(40)"))

--- a/src/main/java/com/almondia/meca/member/domain/entity/Member.java
+++ b/src/main/java/com/almondia/meca/member/domain/entity/Member.java
@@ -30,7 +30,7 @@ public class Member extends DateEntity {
 	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, columnDefinition = "BINARY(16)"))
 	private Id memberId;
 
-	@Column(name = "oauth_id", nullable = false, length = 40, unique = true)
+	@Column(name = "oauth_id", nullable = false, unique = true)
 	private String oauthId;
 
 	@Embedded

--- a/src/main/java/com/almondia/meca/member/domain/vo/Name.java
+++ b/src/main/java/com/almondia/meca/member/domain/vo/Name.java
@@ -1,8 +1,5 @@
 package com.almondia.meca.member.domain.vo;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import javax.persistence.Embeddable;
 
 import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
@@ -16,7 +13,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Name implements Wrapper {
 
-	private static final Pattern NAME_PATTERN = Pattern.compile("^[a-zA-Z가-힣\\s]{1,20}$");
+	private static final int MAX_LENGTH = 20;
+	private static final int MIN_LENGTH = 1;
 	private String name;
 
 	public Name(String name) {
@@ -29,9 +27,8 @@ public class Name implements Wrapper {
 		if (name.isBlank()) {
 			throw new IllegalArgumentException("빈 공백을 입력할 수 없습니다");
 		}
-		Matcher matcher = NAME_PATTERN.matcher(name);
-		if (!matcher.find()) {
-			throw new IllegalArgumentException("이름은 영문 또는 한글 1 ~ 20 사이만 입력 가능합니다");
+		if (name.length() > MAX_LENGTH || name.length() < MIN_LENGTH) {
+			throw new IllegalArgumentException("이름은 1 ~ 20 사이만 입력 가능합니다");
 		}
 	}
 

--- a/src/main/java/com/almondia/meca/member/repository/MemberRepository.java
+++ b/src/main/java/com/almondia/meca/member/repository/MemberRepository.java
@@ -1,9 +1,12 @@
 package com.almondia.meca.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.member.domain.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Id> {
+	Optional<Member> findByOauthId(String oAuthId);
 }

--- a/src/main/java/com/almondia/meca/member/service/MemberService.java
+++ b/src/main/java/com/almondia/meca/member/service/MemberService.java
@@ -43,6 +43,11 @@ public class MemberService {
 	}
 
 	@Transactional(readOnly = true)
+	public Member findMemberByOAuthId(String oauthId) {
+		return memberRepository.findByOauthId(oauthId).orElse(null);
+	}
+
+	@Transactional(readOnly = true)
 	public MemberResponseDto findMyProfile(Id memberId) {
 		Member member = findMember(memberId);
 		return MemberMapper.fromEntityToDto(member);

--- a/src/main/java/com/almondia/meca/member/service/MemberService.java
+++ b/src/main/java/com/almondia/meca/member/service/MemberService.java
@@ -21,6 +21,7 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 
+	@Transactional
 	public Member save(OAuth2UserAttribute oauth2UserAttribute) {
 		Email email = oauth2UserAttribute.getEmail() == null ? null : new Email(oauth2UserAttribute.getEmail());
 		Member member = Member.builder()

--- a/src/main/java/com/almondia/meca/member/service/MemberService.java
+++ b/src/main/java/com/almondia/meca/member/service/MemberService.java
@@ -25,7 +25,7 @@ public class MemberService {
 		Email email = oauth2UserAttribute.getEmail() == null ? null : new Email(oauth2UserAttribute.getEmail());
 		Member member = Member.builder()
 			.memberId(Id.generateNextId())
-			.oAuthId(oauth2UserAttribute.getOAuthId())
+			.oauthId(oauth2UserAttribute.getOAuthId())
 			.name(new Name(oauth2UserAttribute.getName()))
 			.oAuthType(oauth2UserAttribute.getOauthType())
 			.email(email)

--- a/src/test/java/com/almondia/meca/member/domain/entity/MemberTest.java
+++ b/src/test/java/com/almondia/meca/member/domain/entity/MemberTest.java
@@ -45,7 +45,7 @@ class MemberTest {
 		assertThat(entityType).isNotNull();
 		assertThat(entityType.getName()).isEqualTo("Member");
 		assertThat(entityType.getAttributes()).extracting("name")
-			.containsExactlyInAnyOrder("oAuthId", "memberId", "name", "email", "oAuthType", "createdAt", "modifiedAt",
+			.containsExactlyInAnyOrder("oauthId", "memberId", "name", "email", "oAuthType", "createdAt", "modifiedAt",
 				"role", "isDeleted");
 	}
 
@@ -55,7 +55,7 @@ class MemberTest {
 		JpaRepository<Member, Id> memberRepository = new SimpleJpaRepository<>(Member.class, entityManager);
 		Member member = Member.builder()
 			.memberId(Id.generateNextId())
-			.oAuthId("id")
+			.oauthId("id")
 			.email(new Email("hello@naver.com"))
 			.name(new Name("hello"))
 			.oAuthType(OAuthType.GOOGLE)

--- a/src/test/java/com/almondia/meca/member/domain/vo/NameTest.java
+++ b/src/test/java/com/almondia/meca/member/domain/vo/NameTest.java
@@ -4,12 +4,10 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * 1. toString 시 내부 객체의 정보를 보여준다.
- * 2. 영문자, 또는 한글 1 ~ 20까지 허용한다.
+ * 2. 문자열 길이는 1 ~ 20까지 허용한다
  * 3. 빈 공백을 입력으로 할 수 없다.
  */
 class NameTest {
@@ -27,11 +25,9 @@ class NameTest {
 		assertThat(name.toString()).isEqualTo("최 번개");
 	}
 
-	@ParameterizedTest
-	@CsvSource({
-		"as1", "12", "aaasdfaasdsdsdsdsdsdaa", "가1",
-	})
-	void shouldThrowIllegalArgumentExceptionWhenInvalidInput(String input) {
-		assertThatThrownBy(() -> new Name(input)).isInstanceOf(IllegalArgumentException.class);
+	@Test
+	@DisplayName("문자열 길이는 1 ~ 20까지 허용한다")
+	void shouldThrowIllegalArgumentExceptionWhenInvalidInput() {
+		assertThatThrownBy(() -> new Name("a".repeat(21))).isInstanceOf(IllegalArgumentException.class);
 	}
 }

--- a/src/test/java/com/almondia/meca/member/service/MemberServiceTest.java
+++ b/src/test/java/com/almondia/meca/member/service/MemberServiceTest.java
@@ -63,7 +63,7 @@ class MemberServiceTest {
 		Id id = Id.generateNextId();
 		Member member = Member.builder()
 			.memberId(id)
-			.oAuthId("id")
+			.oauthId("id")
 			.oAuthType(OAuthType.KAKAO)
 			.name(new Name("hello"))
 			.email(new Email("hello@naver.com"))
@@ -84,7 +84,7 @@ class MemberServiceTest {
 		Id id = Id.generateNextId();
 		Member member = Member.builder()
 			.memberId(id)
-			.oAuthId("id")
+			.oauthId("id")
 			.oAuthType(OAuthType.KAKAO)
 			.name(new Name("hello"))
 			.email(new Email("hello@naver.com"))


### PR DESCRIPTION
## 요약

- 회원의 oauth 고유 ID를 활용해서 회원 식별
- 새로 생성시 응답 201, 기존에 있는 경우 응답 200
- oauthId를 활용해 회원 정보 쿼리 로직 추가
