### PR TITLE
feat/#84: 카테고리의 카드 갯수 조회 API 추가

### DIFF
--- a/src/main/java/com/almondia/meca/card/application/CardService.java
+++ b/src/main/java/com/almondia/meca/card/application/CardService.java
@@ -89,12 +89,19 @@ public class CardService {
 		cardHistories.forEach(CardHistory::delete);
 	}
 
+	@Transactional(readOnly = true)
 	public CardResponseDto findCardById(Id cardId, Id memberId) {
 		Card card = cardChecker.checkAuthority(cardId, memberId);
 		if (card.isDeleted()) {
 			throw new IllegalArgumentException("삭제된 카드입니다");
 		}
 		return CardMapper.cardToDto(card);
+	}
+
+	@Transactional(readOnly = true)
+	public long findCardsCountByCategoryId(Id categoryId, Id memberId) {
+		categoryChecker.checkAuthority(categoryId, memberId);
+		return cardRepository.countCardsByCategoryId(categoryId);
 	}
 
 	private void updateCard(UpdateCardRequestDto updateCardRequestDto, Id memberId, Card card) {

--- a/src/main/java/com/almondia/meca/card/controller/CardController.java
+++ b/src/main/java/com/almondia/meca/card/controller/CardController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.almondia.meca.card.application.CardService;
 import com.almondia.meca.card.application.CardSimulationService;
+import com.almondia.meca.card.controller.dto.CardCountResponseDto;
 import com.almondia.meca.card.controller.dto.CardResponseDto;
 import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
 import com.almondia.meca.card.controller.dto.UpdateCardRequestDto;
@@ -103,6 +104,16 @@ public class CardController {
 			return ResponseEntity.ok(scores);
 		}
 		throw new IllegalArgumentException("algorithm: random, score 중 하나를 입력해주세요");
+	}
+
+	@Secured("ROLE_USER")
+	@GetMapping("/categories/{categoryId}/me/count")
+	public ResponseEntity<CardCountResponseDto> countCards(
+		@AuthenticationPrincipal Member member,
+		@PathVariable(value = "categoryId") Id categoryId
+	) {
+		long count = cardService.findCardsCountByCategoryId(categoryId, member.getMemberId());
+		return ResponseEntity.ok(new CardCountResponseDto(count));
 	}
 
 	@Secured("ROLE_USER")

--- a/src/main/java/com/almondia/meca/card/controller/dto/CardCountResponseDto.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/CardCountResponseDto.java
@@ -1,0 +1,10 @@
+package com.almondia.meca.card.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CardCountResponseDto {
+	private final long count;
+}

--- a/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepository.java
+++ b/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepository.java
@@ -15,4 +15,6 @@ public interface CardQueryDslRepository {
 	Map<Id, List<Id>> findMapByListOfCardIdAndMemberId(List<Id> cardIds, Id memberId);
 
 	List<Card> findCardByCategoryIdScoreAsc(Id categoryId, int limit);
+
+	long countCardsByCategoryId(Id categoryId);
 }

--- a/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepositoryImpl.java
@@ -62,4 +62,14 @@ public class CardQueryDslRepositoryImpl implements CardQueryDslRepository {
 			.limit(limit)
 			.fetch();
 	}
+
+	@Override
+	public long countCardsByCategoryId(Id categoryId) {
+		Long count = queryFactory.select(card.count())
+			.from(card)
+			.where(card.isDeleted.eq(false)
+				.and(card.categoryId.eq(categoryId)))
+			.fetchOne();
+		return count == null ? 0 : count;
+	}
 }

--- a/src/test/java/com/almondia/meca/card/application/CardServiceTest.java
+++ b/src/test/java/com/almondia/meca/card/application/CardServiceTest.java
@@ -312,4 +312,52 @@ class CardServiceTest {
 			));
 		}
 	}
+
+	/**
+	 * 1. 권한이 없는데 접근한 경우
+	 * 2. 카테고리별 카드 총 조회 API
+	 */
+	@Nested
+	@DisplayName("카테고리별 카드 총 조회 API")
+	class SearchCardsCountByCategoryIdTest {
+
+		Id cardId1 = Id.generateNextId();
+		Id categoryId = Id.generateNextId();
+		Id memberId = Id.generateNextId();
+
+		@Test
+		@DisplayName("권한이 없는데 접근한 경우")
+		void shouldThrowExceptionWhenNotMyCategoryTest() {
+			initDataSetting();
+			assertThatThrownBy(() -> cardService.findCardsCountByCategoryId(Id.generateNextId(), Id.generateNextId()))
+				.isInstanceOf(AccessDeniedException.class);
+		}
+
+		@Test
+		@DisplayName("카테고리별 카드 총 조회 API")
+		void shouldReturnCardsCountByCategoryIdTest() {
+			initDataSetting();
+			assertThat(cardService.findCardsCountByCategoryId(categoryId, memberId)).isEqualTo(1);
+		}
+
+		private void initDataSetting() {
+			cardRepository.saveAll(List.of(
+				MultiChoiceCard.builder()
+					.cardId(cardId1)
+					.title(new Title("title3"))
+					.cardType(CardType.MULTI_CHOICE)
+					.categoryId(categoryId)
+					.memberId(memberId)
+					.question(new Question("question"))
+					.multiChoiceAnswer(new MultiChoiceAnswer(1))
+					.build()
+			));
+
+			em.persist(Category.builder()
+				.title(new com.almondia.meca.category.domain.vo.Title("title"))
+				.memberId(memberId)
+				.categoryId(categoryId)
+				.build());
+		}
+	}
 }

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -285,4 +285,20 @@ class CardControllerTest {
 				.andExpect(jsonPath("$[0].title").exists());
 		}
 	}
+
+	@Nested
+	@DisplayName("카테고리 별 카드 갯수 조회 API")
+	class FindCardCountByCategoryTest {
+
+		@Test
+		@WithMockMember
+		@DisplayName("정상 동작시 200 응답 및 응답 포맷 테스트")
+		void shouldReturn200OKAndResponseFormatTest() throws Exception {
+			Mockito.doReturn(1L)
+				.when(cardService).findCardsCountByCategoryId(any(), any());
+			mockMvc.perform(get("/api/v1/cards//categories/{categoryId}/me/count", Id.generateNextId()))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("count").exists());
+		}
+	}
 }

--- a/src/test/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepositoryImplTest.java
@@ -154,4 +154,11 @@ class CardQueryDslRepositoryImplTest {
 		assertThat(cards).hasSize(5);
 	}
 
+	@Test
+	@DisplayName("countCardsByCategoryId 카드 총 조회")
+	void shouldReturnCountWhenCallCountCardsByCategoryIdTest() {
+		long count = cardRepository.countCardsByCategoryId(categoryId);
+		assertThat(count).isEqualTo(5);
+	}
+
 }


### PR DESCRIPTION
## 요약

- 카테고리 아이디를 입력하면 카드 갯수 조회함
- 카테고리가 본인의 것인지 조회
- URI : /api/v1/cards/categories/{categoryId}/me/count
- 인증을 해야 함