### PR TITLE
refactor/#88: extension 유효성 검증 추가

### DIFF
--- a/src/main/java/com/almondia/meca/auth/s3/controller/PreSignedController.java
+++ b/src/main/java/com/almondia/meca/auth/s3/controller/PreSignedController.java
@@ -27,7 +27,7 @@ public class PreSignedController {
 
 	private final S3PreSignedUrlRequest s3PreSignedUrlRequest;
 
-	@GetMapping("/s3/post")
+	@GetMapping("/images/put")
 	@Secured("ROLE_USER")
 	public ResponseEntity<PreSignedUrlResponseDto> getPostPreSignedUrl(
 		@AuthenticationPrincipal Member member,
@@ -37,7 +37,7 @@ public class PreSignedController {
 		String objectKey = makeObjectKey(member, purpose, extension);
 		Date expirationDate = Date.from(Instant.now().plusSeconds(300L));
 		String url = s3PreSignedUrlRequest.requestPutPreSignedUrl(objectKey, expirationDate).toString();
-		return ResponseEntity.ok(new PreSignedUrlResponseDto(url, expirationDate));
+		return ResponseEntity.ok(new PreSignedUrlResponseDto(url, expirationDate, objectKey));
 	}
 
 	private String makeObjectKey(Member member, Purpose purpose, ImageExtension extension) {

--- a/src/main/java/com/almondia/meca/auth/s3/controller/PreSignedController.java
+++ b/src/main/java/com/almondia/meca/auth/s3/controller/PreSignedController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.almondia.meca.auth.s3.controller.dto.PreSignedUrlResponseDto;
+import com.almondia.meca.auth.s3.domain.vo.ImageExtension;
 import com.almondia.meca.auth.s3.domain.vo.Purpose;
 import com.almondia.meca.common.infra.s3.S3PreSignedUrlRequest;
 import com.almondia.meca.member.domain.entity.Member;
@@ -31,12 +32,16 @@ public class PreSignedController {
 	public ResponseEntity<PreSignedUrlResponseDto> getPostPreSignedUrl(
 		@AuthenticationPrincipal Member member,
 		@RequestParam(name = "purpose") Purpose purpose,
-		@RequestParam(name = "extension") String extension
+		@RequestParam(name = "extension") ImageExtension extension
 	) {
-		String objectKey =
-			member.getMemberId().toString() + "/" + purpose.getDetails() + "/" + UUID.randomUUID() + "." + extension;
+		String objectKey = makeObjectKey(member, purpose, extension);
 		Date expirationDate = Date.from(Instant.now().plusSeconds(300L));
 		String url = s3PreSignedUrlRequest.requestPutPreSignedUrl(objectKey, expirationDate).toString();
 		return ResponseEntity.ok(new PreSignedUrlResponseDto(url, expirationDate));
+	}
+
+	private String makeObjectKey(Member member, Purpose purpose, ImageExtension extension) {
+		return member.getMemberId().toString() + "/" + purpose.getDetails() + "/" + UUID.randomUUID() + "."
+			+ extension.getExtension();
 	}
 }

--- a/src/main/java/com/almondia/meca/auth/s3/controller/PreSignedController.java
+++ b/src/main/java/com/almondia/meca/auth/s3/controller/PreSignedController.java
@@ -27,7 +27,7 @@ public class PreSignedController {
 
 	private final S3PreSignedUrlRequest s3PreSignedUrlRequest;
 
-	@GetMapping("/images/put")
+	@GetMapping("/images/upload")
 	@Secured("ROLE_USER")
 	public ResponseEntity<PreSignedUrlResponseDto> getPostPreSignedUrl(
 		@AuthenticationPrincipal Member member,

--- a/src/main/java/com/almondia/meca/auth/s3/controller/dto/PreSignedUrlResponseDto.java
+++ b/src/main/java/com/almondia/meca/auth/s3/controller/dto/PreSignedUrlResponseDto.java
@@ -11,9 +11,11 @@ public class PreSignedUrlResponseDto {
 
 	private final String url;
 	private final LocalDateTime expirationDate;
+	private final String objectKey;
 
-	public PreSignedUrlResponseDto(String url, Date date) {
+	public PreSignedUrlResponseDto(String url, Date date, String objectKey) {
 		this.url = url;
 		this.expirationDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+		this.objectKey = objectKey;
 	}
 }

--- a/src/main/java/com/almondia/meca/auth/s3/domain/vo/ImageExtension.java
+++ b/src/main/java/com/almondia/meca/auth/s3/domain/vo/ImageExtension.java
@@ -17,7 +17,7 @@ public enum ImageExtension {
 
 	public static ImageExtension fromString(String extension) {
 		for (ImageExtension imageExtension : ImageExtension.values()) {
-			if (imageExtension.extension.equals(extension)) {
+			if (imageExtension.extension.equalsIgnoreCase(extension)) {
 				return imageExtension;
 			}
 		}

--- a/src/main/java/com/almondia/meca/auth/s3/domain/vo/ImageExtension.java
+++ b/src/main/java/com/almondia/meca/auth/s3/domain/vo/ImageExtension.java
@@ -1,0 +1,26 @@
+package com.almondia.meca.auth.s3.domain.vo;
+
+import lombok.Getter;
+
+@Getter
+public enum ImageExtension {
+	PNG("png"),
+	JPEG("jpeg"),
+	JPG("jpg"),
+	GIF("gif");
+
+	private final String extension;
+
+	ImageExtension(String extension) {
+		this.extension = extension;
+	}
+
+	public static ImageExtension fromString(String extension) {
+		for (ImageExtension imageExtension : ImageExtension.values()) {
+			if (imageExtension.extension.equals(extension)) {
+				return imageExtension;
+			}
+		}
+		throw new IllegalArgumentException("Invalid extension: " + extension);
+	}
+}

--- a/src/main/java/com/almondia/meca/common/configuration/web/StringToImageExtensionConverter.java
+++ b/src/main/java/com/almondia/meca/common/configuration/web/StringToImageExtensionConverter.java
@@ -1,0 +1,16 @@
+package com.almondia.meca.common.configuration.web;
+
+import org.springframework.core.convert.converter.Converter;
+
+import com.almondia.meca.auth.s3.domain.vo.ImageExtension;
+
+import lombok.NonNull;
+
+public class StringToImageExtensionConverter implements Converter<String, ImageExtension> {
+
+	@Override
+	public ImageExtension convert(@NonNull String source) {
+		return ImageExtension.fromString(source);
+	}
+}
+

--- a/src/main/java/com/almondia/meca/common/configuration/web/WebMvcConfiguration.java
+++ b/src/main/java/com/almondia/meca/common/configuration/web/WebMvcConfiguration.java
@@ -15,5 +15,6 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 		registry.addConverter(new StringToLocalDateTimeConverter());
 		registry.addConverter(new StringToIdConverter());
 		registry.addConverter(new StringToPurposeConverter());
+		registry.addConverter(new StringToImageExtensionConverter());
 	}
 }

--- a/src/test/java/com/almondia/meca/auth/s3/controller/PreSignedControllerTest.java
+++ b/src/test/java/com/almondia/meca/auth/s3/controller/PreSignedControllerTest.java
@@ -43,7 +43,7 @@ class PreSignedControllerTest {
 	void successResponseOkAndGetUrlTest() throws Exception {
 		URL url = UriComponentsBuilder.fromUriString("https://www.abc.com").build().toUri().toURL();
 		Mockito.doReturn(url).when(s3PreSignedUrlRequest).requestPutPreSignedUrl(any(), any());
-		mockMvc.perform(get("/api/v1/presign/images/put?purpose=thumbnail&extension=jpg"))
+		mockMvc.perform(get("/api/v1/presign/images/upload?purpose=thumbnail&extension=jpg"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("url").exists())
 			.andExpect(jsonPath("expirationDate").exists())

--- a/src/test/java/com/almondia/meca/auth/s3/controller/PreSignedControllerTest.java
+++ b/src/test/java/com/almondia/meca/auth/s3/controller/PreSignedControllerTest.java
@@ -43,9 +43,10 @@ class PreSignedControllerTest {
 	void successResponseOkAndGetUrlTest() throws Exception {
 		URL url = UriComponentsBuilder.fromUriString("https://www.abc.com").build().toUri().toURL();
 		Mockito.doReturn(url).when(s3PreSignedUrlRequest).requestPutPreSignedUrl(any(), any());
-		mockMvc.perform(get("/api/v1/presign/s3/post?purpose=thumbnail&extension=jpg"))
+		mockMvc.perform(get("/api/v1/presign/images/put?purpose=thumbnail&extension=jpg"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("url").exists())
-			.andExpect(jsonPath("expirationDate").exists());
+			.andExpect(jsonPath("expirationDate").exists())
+			.andExpect(jsonPath("objectKey").exists());
 	}
 }

--- a/src/test/java/com/almondia/meca/auth/s3/domain/vo/ImageExtensionTest.java
+++ b/src/test/java/com/almondia/meca/auth/s3/domain/vo/ImageExtensionTest.java
@@ -1,0 +1,55 @@
+package com.almondia.meca.auth.s3.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * 1. fromString의 예외 테스트
+ * 2. fromString 정상 테스트
+ * 3. fromString의 대소문자 테스트
+ * 4. fromString의 공백 테스트
+ * 5. fromString의 null 테스트
+ */
+class ImageExtensionTest {
+
+	@Test
+	@DisplayName("fromString의 예외 테스트")
+	void fromStringExceptionTest() {
+		assertThrows(IllegalArgumentException.class, () -> ImageExtension.fromString("pnga"));
+	}
+
+	@ParameterizedTest
+	@DisplayName("fromString 정상 테스트")
+	@CsvSource({
+		"png",
+		"jpeg",
+		"jpg",
+		"gif"
+	})
+	void fromStringTest(String input) {
+		assertThat(ImageExtension.fromString(input)).isNotNull();
+	}
+
+	@Test
+	@DisplayName("fromString의 대소문자 테스트")
+	void fromStringCaseTest() {
+		assertEquals(ImageExtension.PNG, ImageExtension.fromString("PNG"));
+	}
+
+	@Test
+	@DisplayName("fromString의 공백 테스트")
+	void fromStringSpaceTest() {
+		assertThrows(IllegalArgumentException.class, () -> ImageExtension.fromString(" "));
+	}
+
+	@Test
+	@DisplayName("fromString의 null 테스트")
+	void fromStringNullTest() {
+		assertThrows(IllegalArgumentException.class, () -> ImageExtension.fromString(null));
+	}
+}


### PR DESCRIPTION
## 요약

- extension 유효성 검증 추가(jpg, jpeg, gif, png) 입력만 가능 
- 대소문자를 구분하지 않는다
- URI 경로 수정
    - uri: /api/v1/presign/images/upload