### PR TITLE
feat/#90: get presigned url API 추가

### DIFF
--- a/src/main/java/com/almondia/meca/auth/s3/controller/PreSignedController.java
+++ b/src/main/java/com/almondia/meca/auth/s3/controller/PreSignedController.java
@@ -2,7 +2,9 @@ package com.almondia.meca.auth.s3.controller;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.almondia.meca.auth.s3.controller.dto.DownloadPreSignedUrlResponseDto;
+import com.almondia.meca.auth.s3.controller.dto.MultiDownloadPreSignedUrlResponseDto;
 import com.almondia.meca.auth.s3.controller.dto.UploadPreSignedUrlResponseDto;
 import com.almondia.meca.auth.s3.domain.vo.ImageExtension;
 import com.almondia.meca.auth.s3.domain.vo.Purpose;
@@ -49,6 +52,18 @@ public class PreSignedController {
 		Date expirationDate = Date.from(Instant.now().plusSeconds(300L));
 		String url = s3PreSignedUrlRequest.requestGetPreSignedUrl(objectKey, expirationDate).toString();
 		return ResponseEntity.ok(new DownloadPreSignedUrlResponseDto(url, expirationDate));
+	}
+
+	@GetMapping("/images/download/all")
+	@Secured("ROLE_USER")
+	public ResponseEntity<MultiDownloadPreSignedUrlResponseDto> getAllDownloadPreSignedUrl(
+		@RequestParam(name = "objectKey") List<String> objectKeys
+	) {
+		Date expirationDate = Date.from(Instant.now().plusSeconds(300L));
+		List<String> urls = objectKeys.stream()
+			.map(objectKey -> s3PreSignedUrlRequest.requestGetPreSignedUrl(objectKey, expirationDate).toString())
+			.collect(Collectors.toList());
+		return ResponseEntity.ok(new MultiDownloadPreSignedUrlResponseDto(urls, expirationDate));
 	}
 
 	private String makeObjectKey(Member member, Purpose purpose, ImageExtension extension) {

--- a/src/main/java/com/almondia/meca/auth/s3/controller/PreSignedController.java
+++ b/src/main/java/com/almondia/meca/auth/s3/controller/PreSignedController.java
@@ -12,7 +12,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.almondia.meca.auth.s3.controller.dto.PreSignedUrlResponseDto;
+import com.almondia.meca.auth.s3.controller.dto.DownloadPreSignedUrlResponseDto;
+import com.almondia.meca.auth.s3.controller.dto.UploadPreSignedUrlResponseDto;
 import com.almondia.meca.auth.s3.domain.vo.ImageExtension;
 import com.almondia.meca.auth.s3.domain.vo.Purpose;
 import com.almondia.meca.common.infra.s3.S3PreSignedUrlRequest;
@@ -29,7 +30,7 @@ public class PreSignedController {
 
 	@GetMapping("/images/upload")
 	@Secured("ROLE_USER")
-	public ResponseEntity<PreSignedUrlResponseDto> getPostPreSignedUrl(
+	public ResponseEntity<UploadPreSignedUrlResponseDto> getUploadPreSignedUrl(
 		@AuthenticationPrincipal Member member,
 		@RequestParam(name = "purpose") Purpose purpose,
 		@RequestParam(name = "extension") ImageExtension extension
@@ -37,7 +38,17 @@ public class PreSignedController {
 		String objectKey = makeObjectKey(member, purpose, extension);
 		Date expirationDate = Date.from(Instant.now().plusSeconds(300L));
 		String url = s3PreSignedUrlRequest.requestPutPreSignedUrl(objectKey, expirationDate).toString();
-		return ResponseEntity.ok(new PreSignedUrlResponseDto(url, expirationDate, objectKey));
+		return ResponseEntity.ok(new UploadPreSignedUrlResponseDto(url, expirationDate, objectKey));
+	}
+
+	@GetMapping("/images/download")
+	@Secured("ROLE_USER")
+	public ResponseEntity<DownloadPreSignedUrlResponseDto> getDownloadPreSignedUrl(
+		@RequestParam(name = "objectKey") String objectKey
+	) {
+		Date expirationDate = Date.from(Instant.now().plusSeconds(300L));
+		String url = s3PreSignedUrlRequest.requestGetPreSignedUrl(objectKey, expirationDate).toString();
+		return ResponseEntity.ok(new DownloadPreSignedUrlResponseDto(url, expirationDate));
 	}
 
 	private String makeObjectKey(Member member, Purpose purpose, ImageExtension extension) {

--- a/src/main/java/com/almondia/meca/auth/s3/controller/dto/DownloadPreSignedUrlResponseDto.java
+++ b/src/main/java/com/almondia/meca/auth/s3/controller/dto/DownloadPreSignedUrlResponseDto.java
@@ -1,0 +1,19 @@
+package com.almondia.meca.auth.s3.controller.dto;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import lombok.Getter;
+
+@Getter
+public class DownloadPreSignedUrlResponseDto {
+
+	private final String url;
+	private final LocalDateTime expirationDate;
+
+	public DownloadPreSignedUrlResponseDto(String url, Date expirationDate) {
+		this.url = url;
+		this.expirationDate = expirationDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+	}
+}

--- a/src/main/java/com/almondia/meca/auth/s3/controller/dto/MultiDownloadPreSignedUrlResponseDto.java
+++ b/src/main/java/com/almondia/meca/auth/s3/controller/dto/MultiDownloadPreSignedUrlResponseDto.java
@@ -1,0 +1,20 @@
+package com.almondia.meca.auth.s3.controller.dto;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class MultiDownloadPreSignedUrlResponseDto {
+
+	private final List<String> urls;
+	private final LocalDateTime expirationDate;
+
+	public MultiDownloadPreSignedUrlResponseDto(List<String> urls, Date expirationDate) {
+		this.urls = urls;
+		this.expirationDate = expirationDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+	}
+}

--- a/src/main/java/com/almondia/meca/auth/s3/controller/dto/UploadPreSignedUrlResponseDto.java
+++ b/src/main/java/com/almondia/meca/auth/s3/controller/dto/UploadPreSignedUrlResponseDto.java
@@ -7,13 +7,13 @@ import java.util.Date;
 import lombok.Getter;
 
 @Getter
-public class PreSignedUrlResponseDto {
+public class UploadPreSignedUrlResponseDto {
 
 	private final String url;
 	private final LocalDateTime expirationDate;
 	private final String objectKey;
 
-	public PreSignedUrlResponseDto(String url, Date date, String objectKey) {
+	public UploadPreSignedUrlResponseDto(String url, Date date, String objectKey) {
 		this.url = url;
 		this.expirationDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
 		this.objectKey = objectKey;

--- a/src/main/java/com/almondia/meca/common/infra/s3/S3PreSignedUrlRequest.java
+++ b/src/main/java/com/almondia/meca/common/infra/s3/S3PreSignedUrlRequest.java
@@ -26,4 +26,12 @@ public class S3PreSignedUrlRequest {
 				.withExpiration(expiration);
 		return s3Client.generatePresignedUrl(generatePresignedUrlRequest);
 	}
+
+	public URL requestGetPreSignedUrl(String objectKey, Date expiration) {
+		GeneratePresignedUrlRequest generatePresignedUrlRequest =
+			new GeneratePresignedUrlRequest(s3Properties.getBucket(), objectKey)
+				.withMethod(HttpMethod.GET)
+				.withExpiration(expiration);
+		return s3Client.generatePresignedUrl(generatePresignedUrlRequest);
+	}
 }

--- a/src/test/java/com/almondia/meca/auth/s3/controller/PreSignedControllerTest.java
+++ b/src/test/java/com/almondia/meca/auth/s3/controller/PreSignedControllerTest.java
@@ -61,4 +61,16 @@ class PreSignedControllerTest {
 			.andExpect(jsonPath("url").exists())
 			.andExpect(jsonPath("expirationDate").exists());
 	}
+
+	@Test
+	@DisplayName("응답 성공시 Multi Download PresignedUrl를 리턴해야함")
+	@WithMockMember
+	void successResponseOkAndGetMultiDownloadUrlTest() throws Exception {
+		URL url = UriComponentsBuilder.fromUriString("https://www.abc.com").build().toUri().toURL();
+		Mockito.doReturn(url).when(s3PreSignedUrlRequest).requestGetPreSignedUrl(any(), any());
+		mockMvc.perform(get("/api/v1/presign/images/download/all?objectKey=abc&objectKey=def"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("urls").exists())
+			.andExpect(jsonPath("expirationDate").exists());
+	}
 }

--- a/src/test/java/com/almondia/meca/auth/s3/controller/PreSignedControllerTest.java
+++ b/src/test/java/com/almondia/meca/auth/s3/controller/PreSignedControllerTest.java
@@ -38,7 +38,7 @@ class PreSignedControllerTest {
 	MockMvc mockMvc;
 
 	@Test
-	@DisplayName("응답 성공시 PresignedUrl를 리턴해야함")
+	@DisplayName("응답 성공시 Upload PresignedUrl를 리턴해야함")
 	@WithMockMember
 	void successResponseOkAndGetUrlTest() throws Exception {
 		URL url = UriComponentsBuilder.fromUriString("https://www.abc.com").build().toUri().toURL();
@@ -48,5 +48,17 @@ class PreSignedControllerTest {
 			.andExpect(jsonPath("url").exists())
 			.andExpect(jsonPath("expirationDate").exists())
 			.andExpect(jsonPath("objectKey").exists());
+	}
+
+	@Test
+	@DisplayName("응답 성공시 Download PresignedUrl를 리턴해야함")
+	@WithMockMember
+	void successResponseOkAndGetDownloadUrlTest() throws Exception {
+		URL url = UriComponentsBuilder.fromUriString("https://www.abc.com").build().toUri().toURL();
+		Mockito.doReturn(url).when(s3PreSignedUrlRequest).requestGetPreSignedUrl(any(), any());
+		mockMvc.perform(get("/api/v1/presign/images/download?objectKey=abc"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("url").exists())
+			.andExpect(jsonPath("expirationDate").exists());
 	}
 }


### PR DESCRIPTION
## 요약

- 단일 get presigned url API 추가 (/api/v1/presign/images/download?objectKey=)
- 여러개의 get presigned url API 추가 (/api/v1/presign/images/download?objectKey=&objectKey=)