### PR TITLE
refactor/#86: 카드 페이징 응답에 카테고리가 포함하도록 개선

### DIFF
--- a/src/main/java/com/almondia/meca/card/application/CardService.java
+++ b/src/main/java/com/almondia/meca/card/application/CardService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.almondia.meca.card.application.helper.CardFactory;
 import com.almondia.meca.card.application.helper.CardMapper;
+import com.almondia.meca.card.controller.dto.CardCursorPageWithCategory;
 import com.almondia.meca.card.controller.dto.CardResponseDto;
 import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
 import com.almondia.meca.card.controller.dto.UpdateCardRequestDto;
@@ -17,6 +18,7 @@ import com.almondia.meca.card.infra.querydsl.CardSearchCriteria;
 import com.almondia.meca.card.infra.querydsl.CardSortField;
 import com.almondia.meca.cardhistory.domain.entity.CardHistory;
 import com.almondia.meca.cardhistory.domain.repository.CardHistoryRepository;
+import com.almondia.meca.category.domain.entity.Category;
 import com.almondia.meca.category.domain.service.CategoryChecker;
 import com.almondia.meca.common.controller.dto.CursorPage;
 import com.almondia.meca.common.domain.vo.Id;
@@ -55,10 +57,13 @@ public class CardService {
 		SortOption<CardSortField> sortOption,
 		Id memberId
 	) {
-		categoryChecker.checkAuthority(categoryId, memberId);
+		Category category = categoryChecker.checkAuthority(categoryId, memberId);
 		List<Card> cursor = cardRepository.findCardByCategoryIdUsingCursorPaging(pageSize,
 			cardSearchCriteria, sortOption);
-		return CardMapper.cardsToCursorPagingDto(cursor, pageSize, sortOption.getSortOrder());
+		CardCursorPageWithCategory cardCursorPageWithCategory = CardMapper.cardsToCursorPagingDto(cursor, pageSize,
+			sortOption.getSortOrder());
+		cardCursorPageWithCategory.setCategory(category);
+		return cardCursorPageWithCategory;
 	}
 
 	@Transactional

--- a/src/main/java/com/almondia/meca/card/application/helper/CardMapper.java
+++ b/src/main/java/com/almondia/meca/card/application/helper/CardMapper.java
@@ -4,19 +4,19 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.almondia.meca.card.controller.dto.CardCursorPageWithCategory;
 import com.almondia.meca.card.controller.dto.CardResponseDto;
 import com.almondia.meca.card.domain.entity.Card;
 import com.almondia.meca.card.domain.entity.KeywordCard;
 import com.almondia.meca.card.domain.entity.MultiChoiceCard;
 import com.almondia.meca.card.domain.entity.OxCard;
 import com.almondia.meca.card.domain.vo.CardType;
-import com.almondia.meca.common.controller.dto.CursorPage;
 import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.common.infra.querydsl.SortOrder;
 
 public class CardMapper {
 
-	public static CursorPage<CardResponseDto> cardsToCursorPagingDto(
+	public static CardCursorPageWithCategory cardsToCursorPagingDto(
 		List<Card> contents,
 		int pageSize,
 		SortOrder sortOrder
@@ -26,12 +26,7 @@ public class CardMapper {
 		if (contents.size() == pageSize) {
 			lastId = responses.get(responses.size() - 1).getCardId();
 		}
-		return CursorPage.<CardResponseDto>builder()
-			.contents(responses)
-			.pageSize(pageSize)
-			.hasNext(lastId)
-			.sortOrder(sortOrder)
-			.build();
+		return new CardCursorPageWithCategory(responses, lastId, pageSize, sortOrder);
 	}
 
 	public static CardResponseDto cardToDto(Card card) {

--- a/src/main/java/com/almondia/meca/card/controller/dto/CardCursorPageWithCategory.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/CardCursorPageWithCategory.java
@@ -1,0 +1,31 @@
+package com.almondia.meca.card.controller.dto;
+
+import java.util.List;
+
+import com.almondia.meca.category.controller.dto.CategoryResponseDto;
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.common.controller.dto.CursorPage;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.common.infra.querydsl.SortOrder;
+
+import lombok.Getter;
+
+@Getter
+public class CardCursorPageWithCategory extends CursorPage<CardResponseDto> {
+
+	private CategoryResponseDto category;
+
+	public CardCursorPageWithCategory(List<CardResponseDto> contents, Id hasNext, int pageSize, SortOrder sortOrder) {
+		super(contents, hasNext, pageSize, sortOrder);
+	}
+
+	public void setCategory(Category category) {
+		this.category = CategoryResponseDto.builder()
+			.categoryId(category.getCategoryId())
+			.title(category.getTitle())
+			.createdAt(category.getCreatedAt())
+			.modifiedAt(category.getModifiedAt())
+			.memberId(category.getMemberId())
+			.build();
+	}
+}


### PR DESCRIPTION
## 요약

- 페이징 응답에 카테고리가 포함됨
- 카드 매퍼와 서비스 일부 로직을 카테고리를 포함하도록 수정