### PR TITLE
fix/#108: 카테고리, 카드 버그 수정

### DIFF
--- a/src/main/java/com/almondia/meca/card/controller/dto/CardCursorPageWithCategory.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/CardCursorPageWithCategory.java
@@ -27,6 +27,8 @@ public class CardCursorPageWithCategory extends CursorPage<CardResponseDto> {
 			.createdAt(category.getCreatedAt())
 			.modifiedAt(category.getModifiedAt())
 			.memberId(category.getMemberId())
+			.isShared(category.isShared())
+			.isDeleted(category.isDeleted())
 			.build();
 	}
 }

--- a/src/main/java/com/almondia/meca/card/controller/dto/CardCursorPageWithCategory.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/CardCursorPageWithCategory.java
@@ -23,6 +23,7 @@ public class CardCursorPageWithCategory extends CursorPage<CardResponseDto> {
 		this.category = CategoryResponseDto.builder()
 			.categoryId(category.getCategoryId())
 			.title(category.getTitle())
+			.thumbnail(category.getThumbnail())
 			.createdAt(category.getCreatedAt())
 			.modifiedAt(category.getModifiedAt())
 			.memberId(category.getMemberId())

--- a/src/main/java/com/almondia/meca/card/domain/entity/Card.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/Card.java
@@ -60,7 +60,8 @@ public abstract class Card extends DateEntity {
 	@Convert(converter = ListImageConverter.class)
 	private List<Image> images;
 
-	@Column(name = "description", length = 2_1000)
+	@Embedded
+	@AttributeOverride(name = "description", column = @Column(name = "description", nullable = false, length = 2_1000))
 	private Description description;
 
 	@Transient

--- a/src/main/java/com/almondia/meca/card/domain/entity/Card.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/Card.java
@@ -61,7 +61,7 @@ public abstract class Card extends DateEntity {
 	private List<Image> images;
 
 	@Embedded
-	@AttributeOverride(name = "description", column = @Column(name = "description", nullable = false, length = 2_1000))
+	@AttributeOverride(name = "description", column = @Column(name = "description", length = 2_1000, columnDefinition = "TEXT"))
 	private Description description;
 
 	@Transient

--- a/src/main/java/com/almondia/meca/category/infra/querydsl/CategoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/category/infra/querydsl/CategoryQueryDslRepositoryImpl.java
@@ -127,7 +127,7 @@ public class CategoryQueryDslRepositoryImpl implements CategoryQueryDslRepositor
 		}
 		return CursorPage.<CategoryResponseDto>builder()
 			.contents(response)
-			.pageSize(response.size())
+			.pageSize(pageSize)
 			.hasNext(hasNext)
 			.sortOrder(SortOrder.DESC)
 			.build();

--- a/src/main/java/com/almondia/meca/category/infra/querydsl/CategoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/category/infra/querydsl/CategoryQueryDslRepositoryImpl.java
@@ -87,7 +87,8 @@ public class CategoryQueryDslRepositoryImpl implements CategoryQueryDslRepositor
 					category.createdAt,
 					category.modifiedAt))
 			.from(category)
-			.where(category.isShared.eq(true))
+			.where(cursorPagingExpression(null, lastCategoryId)
+				.and(category.isShared.eq(true)))
 			.orderBy(category.categoryId.uuid.desc())
 			.limit(pageSize + 1)
 			.fetch();
@@ -96,11 +97,12 @@ public class CategoryQueryDslRepositoryImpl implements CategoryQueryDslRepositor
 
 	private BooleanExpression cursorPagingExpression(Id memberId, Id lastCategoryId) {
 		BooleanExpression loe = null;
+		BooleanExpression eqMember = memberId == null ? null : category.memberId.eq(memberId);
 		if (lastCategoryId != null) {
 			loe = category.categoryId.uuid.loe(lastCategoryId.getUuid());
 		}
-		return category.memberId.eq(memberId)
-			.and(category.isDeleted.eq(false))
+		return category.isDeleted.eq(false)
+			.and(eqMember)
 			.and(loe);
 	}
 

--- a/src/test/java/com/almondia/meca/category/infra/querydsl/CategoryQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/almondia/meca/category/infra/querydsl/CategoryQueryDslRepositoryImplTest.java
@@ -215,6 +215,7 @@ class CategoryQueryDslRepositoryImplTest {
 	 * 4. 조회후 다음 페이징 index가 있는 경우 hasNext에 다음 카테고리 id가 존재해야 함
 	 * 5. 조회후 다음 페이징 index가 없는 경우 hasNext에 null이 존재해야 함
 	 * 6. shared가 false인 카테고리는 조회하면 안된다
+	 * 7. "lastCategoryId를 입력받은 경우, lastCategoryId와 같거나 큰 카테고리는 조회되어야 한다"
 	 */
 	@Nested
 	@DisplayName("findCategoryShared 테스트")
@@ -324,6 +325,27 @@ class CategoryQueryDslRepositoryImplTest {
 			// then
 			assertThat(result).isNotNull();
 			assertThat(result.getContents()).isEmpty();
+		}
+
+		@Test
+		@DisplayName("lastCategoryId를 입력받은 경우, lastCategoryId와 같거나 큰 카테고리는 조회되어야 한다")
+		void shouldReturnCategoryWhenLastCategoryIdIsNotNullTest() {
+			// given
+			Id memberId = Id.generateNextId();
+			Id lastCategoryId = Id.generateNextId();
+			int pageSize = 3;
+			em.persist(CategoryTestHelper.generateSharedCategory("title1", memberId, lastCategoryId));
+			em.persist(CategoryTestHelper.generateSharedCategory("title2", memberId, Id.generateNextId()));
+
+			// when
+			CursorPage<CategoryResponseDto> result = categoryRepository.findCategoryShared(
+				pageSize,
+				lastCategoryId);
+
+			// then
+			assertThat(result).isNotNull();
+			assertThat(result.getContents()).isNotEmpty();
+			assertThat(result.getContents().get(0).getCategoryId()).isEqualTo(lastCategoryId);
 		}
 	}
 


### PR DESCRIPTION
## 요약

- 카테고리 커서 페이징시 일부 조회가 정상 동작하지 않던 부분 수정
- 카드 속성 중 description이 TEXT column이 되지 않아 255자 이상 넣지 못한 문제 수정
- 카테고리 응답에 몇가지 누락된 데이터 수정