### PR TITLE
feat/#117: 공유 카테고리 내의 카드 목록 조회시 사용자 정보를 전해줌

### DIFF
--- a/src/main/java/com/almondia/meca/card/application/CardService.java
+++ b/src/main/java/com/almondia/meca/card/application/CardService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.almondia.meca.card.application.helper.CardFactory;
 import com.almondia.meca.card.application.helper.CardMapper;
 import com.almondia.meca.card.controller.dto.CardCursorPageWithCategory;
+import com.almondia.meca.card.controller.dto.CardCursorPageWithSharedCategoryDto;
 import com.almondia.meca.card.controller.dto.CardResponseDto;
 import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
 import com.almondia.meca.card.controller.dto.SharedCardResponseDto;
@@ -114,7 +115,7 @@ public class CardService {
 	}
 
 	@Transactional(readOnly = true)
-	public CursorPage<CardResponseDto> searchCursorPagingSharedCard(int pageSize, Id categoryId,
+	public CardCursorPageWithSharedCategoryDto searchCursorPagingSharedCard(int pageSize, Id categoryId,
 		CardSearchCriteria criteria, SortOption<CardSortField> sortOption
 	) {
 		Category category = categoryRepository.findById(categoryId)
@@ -122,7 +123,7 @@ public class CardService {
 		if (!category.isShared()) {
 			throw new AccessDeniedException("공유되지 않은 카테고리에 접근할 수 없습니다");
 		}
-		CardCursorPageWithCategory cursor = cardRepository.findCardByCategoryIdUsingCursorPaging(pageSize,
+		CardCursorPageWithSharedCategoryDto cursor = cardRepository.findCardBySharedCategoryCursorPaging(pageSize,
 			criteria, sortOption);
 		cursor.setCategory(category);
 		return cursor;

--- a/src/main/java/com/almondia/meca/card/controller/CardController.java
+++ b/src/main/java/com/almondia/meca/card/controller/CardController.java
@@ -78,7 +78,7 @@ public class CardController {
 	}
 
 	@GetMapping("/categories/{categoryId}/share")
-	public ResponseEntity<CursorPage<CardResponseDto>> searchSharedCardPaging(
+	public ResponseEntity<CursorPage<SharedCardResponseDto>> searchSharedCardPaging(
 		@PathVariable("categoryId") Id categoryId,
 		@RequestParam(value = "hasNext", required = false) Id lastId,
 		@RequestParam(value = "pageSize", defaultValue = "1000") int pageSize,
@@ -86,7 +86,7 @@ public class CardController {
 	) {
 		CardSearchCriteria criteria = makeCursorCriteria(categoryId, lastId, sortOrder);
 
-		CursorPage<CardResponseDto> responseDto = cardService.searchCursorPagingSharedCard(pageSize, categoryId,
+		CursorPage<SharedCardResponseDto> responseDto = cardService.searchCursorPagingSharedCard(pageSize, categoryId,
 			criteria,
 			SortOption.of(CardSortField.CARD_ID, sortOrder));
 		return ResponseEntity.ok(responseDto);

--- a/src/main/java/com/almondia/meca/card/controller/dto/CardCursorPageWithSharedCategoryDto.java
+++ b/src/main/java/com/almondia/meca/card/controller/dto/CardCursorPageWithSharedCategoryDto.java
@@ -1,0 +1,27 @@
+package com.almondia.meca.card.controller.dto;
+
+import java.util.List;
+
+import com.almondia.meca.category.application.helper.CategoryMapper;
+import com.almondia.meca.category.controller.dto.CategoryResponseDto;
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.common.controller.dto.CursorPage;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.common.infra.querydsl.SortOrder;
+
+import lombok.Getter;
+
+@Getter
+public class CardCursorPageWithSharedCategoryDto extends CursorPage<SharedCardResponseDto> {
+
+	private CategoryResponseDto category;
+
+	public CardCursorPageWithSharedCategoryDto(List<SharedCardResponseDto> contents, Id hasNext, int pageSize,
+		SortOrder sortOrder) {
+		super(contents, hasNext, pageSize, sortOrder);
+	}
+
+	public void setCategory(Category category) {
+		this.category = CategoryMapper.entityToCategoryResponseDto(category);
+	}
+}

--- a/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepository.java
+++ b/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepository.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.almondia.meca.card.controller.dto.CardCursorPageWithCategory;
+import com.almondia.meca.card.controller.dto.CardCursorPageWithSharedCategoryDto;
 import com.almondia.meca.card.controller.dto.SharedCardResponseDto;
 import com.almondia.meca.card.domain.entity.Card;
 import com.almondia.meca.common.domain.vo.Id;
@@ -13,6 +14,9 @@ import com.almondia.meca.common.infra.querydsl.SortOption;
 public interface CardQueryDslRepository {
 
 	CardCursorPageWithCategory findCardByCategoryIdUsingCursorPaging(int pageSize,
+		CardSearchCriteria criteria, SortOption<CardSortField> sortOption);
+
+	CardCursorPageWithSharedCategoryDto findCardBySharedCategoryCursorPaging(int pageSize,
 		CardSearchCriteria criteria, SortOption<CardSortField> sortOption);
 
 	Optional<SharedCardResponseDto> findCardInSharedCategory(Id cardId);

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -25,10 +25,12 @@ import org.springframework.web.context.WebApplicationContext;
 import com.almondia.meca.card.application.CardService;
 import com.almondia.meca.card.application.CardSimulationService;
 import com.almondia.meca.card.controller.dto.CardCursorPageWithCategory;
+import com.almondia.meca.card.controller.dto.CardCursorPageWithSharedCategoryDto;
 import com.almondia.meca.card.controller.dto.CardResponseDto;
 import com.almondia.meca.card.controller.dto.SaveCardRequestDto;
 import com.almondia.meca.card.controller.dto.SharedCardResponseDto;
 import com.almondia.meca.card.controller.dto.UpdateCardRequestDto;
+import com.almondia.meca.card.domain.entity.Card;
 import com.almondia.meca.card.domain.entity.OxCard;
 import com.almondia.meca.card.domain.vo.CardType;
 import com.almondia.meca.card.domain.vo.Description;
@@ -40,6 +42,8 @@ import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
 import com.almondia.meca.common.configuration.security.filter.JwtAuthenticationFilter;
 import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.common.infra.querydsl.SortOrder;
+import com.almondia.meca.helper.CardTestHelper;
+import com.almondia.meca.helper.MemberTestHelper;
 import com.almondia.meca.member.domain.entity.Member;
 import com.almondia.meca.member.domain.vo.Email;
 import com.almondia.meca.member.domain.vo.Name;
@@ -367,8 +371,9 @@ class CardControllerTest {
 		@Test
 		@DisplayName("정상 동작시 200 응답 및 응답 포맷 테스트")
 		void shouldReturn200OkAndResponseFormatTest() throws Exception {
-			List<CardResponseDto> contents = List.of(makeResponse());
-			CardCursorPageWithCategory cardCursorPageWithCategory = new CardCursorPageWithCategory(contents,
+			List<SharedCardResponseDto> contents = List.of(makeResponse());
+			CardCursorPageWithSharedCategoryDto cardCursorPageWithCategory = new CardCursorPageWithSharedCategoryDto(
+				contents,
 				Id.generateNextId(), 5, SortOrder.DESC);
 			cardCursorPageWithCategory.setCategory(Category.builder()
 				.categoryId(Id.generateNextId())
@@ -386,18 +391,10 @@ class CardControllerTest {
 				.andExpect(jsonPath("category").exists());
 		}
 
-		private CardResponseDto makeResponse() {
-			return CardResponseDto.builder()
-				.cardId(Id.generateNextId())
-				.title(new Title("title"))
-				.question(new Question("hello"))
-				.categoryId(Id.generateNextId())
-				.cardType(CardType.OX_QUIZ)
-				.answer(OxAnswer.O.name())
-				.description(new Description("hello"))
-				.createdAt(LocalDateTime.now())
-				.modifiedAt(LocalDateTime.now())
-				.build();
+		private SharedCardResponseDto makeResponse() {
+			Card card = CardTestHelper.genOxCard(Id.generateNextId(), Id.generateNextId(), Id.generateNextId());
+			Member member = MemberTestHelper.generateMember(Id.generateNextId());
+			return new SharedCardResponseDto(card, member);
 		}
 	}
 }


### PR DESCRIPTION
## 요약

- 공유 카테고리 내의 마드 목록 조회 API 응답 수정 -> 해당 카드의 사용자 정보와 카테고리 정보를 가져옴