### PR TITLE
fix/#130: 공유 카테고리 조회에서 삭제되지 않은 카드의 갯수가 0보다 커야 조회되도록 수정

### DIFF
--- a/src/main/java/com/almondia/meca/card/application/CardSimulationService.java
+++ b/src/main/java/com/almondia/meca/card/application/CardSimulationService.java
@@ -27,7 +27,7 @@ public class CardSimulationService {
 	@Transactional(readOnly = true)
 	public List<CardResponseDto> simulateRandom(Id categoryId, Id memberId, int limit) {
 		categoryChecker.checkAuthority(categoryId, memberId);
-		List<Card> cards = cardRepository.findByCategoryId(categoryId);
+		List<Card> cards = cardRepository.findByCategoryIdAndIsDeleted(categoryId, false);
 		CardPicker cardPicker = new RandomCardPicker();
 		List<Card> pick = cardPicker.pick(cards, limit);
 		return pick.stream().map(CardMapper::cardToDto).collect(Collectors.toList());

--- a/src/main/java/com/almondia/meca/card/domain/repository/CardRepository.java
+++ b/src/main/java/com/almondia/meca/card/domain/repository/CardRepository.java
@@ -12,6 +12,6 @@ import com.almondia.meca.common.domain.vo.Id;
 public interface CardRepository extends JpaRepository<Card, Id>, CardQueryDslRepository {
 	Optional<Card> findByCardIdAndMemberId(Id cardId, Id memberId);
 
-	List<Card> findByCategoryId(Id categoryId);
+	List<Card> findByCategoryIdAndIsDeleted(Id categoryId, boolean isDeleted);
 
 }

--- a/src/main/java/com/almondia/meca/cardhistory/domain/repository/CardHistoryRepository.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/repository/CardHistoryRepository.java
@@ -11,6 +11,6 @@ import com.almondia.meca.common.domain.vo.Id;
 public interface CardHistoryRepository extends JpaRepository<CardHistory, Id> {
 	List<CardHistory> findByCardId(Id cardId);
 
-	List<CardHistory> findByCardIdIn(Collection<Id> cardIds);
+	List<CardHistory> findByCardIdInAndIsDeleted(Collection<Id> cardIds, boolean isDeleted);
 
 }

--- a/src/main/java/com/almondia/meca/category/application/CategoryService.java
+++ b/src/main/java/com/almondia/meca/category/application/CategoryService.java
@@ -61,9 +61,9 @@ public class CategoryService {
 	@Transactional
 	public void deleteCategory(Id categoryId, Id memberId) {
 		Category category = categoryChecker.checkAuthority(categoryId, memberId);
-		List<Card> cards = cardRepository.findByCategoryId(categoryId);
+		List<Card> cards = cardRepository.findByCategoryIdAndIsDeleted(categoryId, false);
 		List<Id> cardIds = cards.stream().map(Card::getCardId).collect(Collectors.toList());
-		List<CardHistory> cardHistories = cardHistoryRepository.findByCardIdIn(cardIds);
+		List<CardHistory> cardHistories = cardHistoryRepository.findByCardIdInAndIsDeleted(cardIds, false);
 		cardHistories.forEach(CardHistory::delete);
 		cards.forEach(Card::delete);
 		category.delete();

--- a/src/main/java/com/almondia/meca/category/infra/querydsl/CategoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/category/infra/querydsl/CategoryQueryDslRepositoryImpl.java
@@ -109,7 +109,9 @@ public class CategoryQueryDslRepositoryImpl implements CategoryQueryDslRepositor
 			.from(category)
 			.where(
 				category.isShared.eq(true),
-				dynamicCursorExpression(lastCategoryId))
+				dynamicCursorExpression(lastCategoryId),
+				card.isDeleted.eq(false)
+			)
 			.innerJoin(member)
 			.on(category.memberId.eq(member.memberId))
 			.leftJoin(card)
@@ -139,6 +141,7 @@ public class CategoryQueryDslRepositoryImpl implements CategoryQueryDslRepositor
 			.where(
 				category.isShared.eq(true),
 				dynamicCursorExpression(lastCategoryId),
+				card.isDeleted.eq(false),
 				containTitle(categorySearchOption.getContainTitle()))
 			.orderBy(category.categoryId.uuid.desc())
 			.limit(pageSize + 1)

--- a/src/test/java/com/almondia/meca/card/application/CardSimulationServiceTest.java
+++ b/src/test/java/com/almondia/meca/card/application/CardSimulationServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,17 +14,17 @@ import org.springframework.security.access.AccessDeniedException;
 import com.almondia.meca.card.controller.dto.CardResponseDto;
 import com.almondia.meca.card.domain.entity.Card;
 import com.almondia.meca.card.domain.repository.CardRepository;
-import com.almondia.meca.category.domain.entity.Category;
 import com.almondia.meca.category.domain.repository.CategoryRepository;
 import com.almondia.meca.category.domain.service.CategoryChecker;
 import com.almondia.meca.common.domain.vo.Id;
-import com.almondia.meca.data.CardDataFactory;
+import com.almondia.meca.helper.CardTestHelper;
+import com.almondia.meca.helper.CategoryTestHelper;
 
 class CardSimulationServiceTest {
 
 	CategoryRepository categoryRepository = Mockito.mock(CategoryRepository.class);
 
-	CategoryChecker categoryChecker = new CategoryChecker(categoryRepository);
+	CategoryChecker categoryChecker = Mockito.mock(CategoryChecker.class);
 
 	CardRepository cardRepository = Mockito.mock(CardRepository.class);
 
@@ -35,7 +34,7 @@ class CardSimulationServiceTest {
 	@Test
 	@DisplayName("simulateRandom 권한 체크 테스트")
 	void randomCheckAuthorityTest() {
-		Mockito.doReturn(Optional.empty()).when(categoryRepository).findByCategoryIdAndMemberId(any(), any());
+		Mockito.doThrow(AccessDeniedException.class).when(categoryChecker).checkAuthority(any(), any());
 		assertThatThrownBy(
 			() -> cardSimulationService.simulateRandom(Id.generateNextId(), Id.generateNextId(), 100)).isInstanceOf(
 			AccessDeniedException.class);
@@ -44,22 +43,25 @@ class CardSimulationServiceTest {
 	@Test
 	@DisplayName("simulateRandom 응답 테스트")
 	void randomResponseTest() {
-		List<Card> testData = new CardDataFactory().createTestData();
-		Mockito.doReturn(Optional.of(Category.builder().build()))
-			.when(categoryRepository)
-			.findByCategoryIdAndMemberId(any(), any());
-		Mockito.doReturn(testData).when(cardRepository).findByCategoryId(any());
-		final int limit = 3;
+		Id memberId = Id.generateNextId();
+		Id categoryId = Id.generateNextId();
+		List<Card> testData = List.of(
+			CardTestHelper.genOxCard(memberId, categoryId, Id.generateNextId()),
+			CardTestHelper.genOxCard(memberId, categoryId, Id.generateNextId()));
+		Mockito.doReturn(CategoryTestHelper.generateUnSharedCategory("title", memberId, categoryId))
+			.when(categoryChecker).checkAuthority(any(), any());
+		Mockito.doReturn(testData).when(cardRepository).findByCategoryIdAndIsDeleted(any(), eq(false));
+		final int limit = 2;
 
 		List<CardResponseDto> randoms = cardSimulationService.simulateRandom(Id.generateNextId(), Id.generateNextId(),
 			limit);
-		assertThat(randoms).doesNotHaveDuplicates().hasSize(3);
+		assertThat(randoms).doesNotHaveDuplicates().hasSize(2);
 	}
 
 	@Test
 	@DisplayName("simulateScore 권한 체크")
 	void scoreCheckAuthorityTest() {
-		Mockito.doReturn(Optional.empty()).when(categoryRepository).findByCategoryIdAndMemberId(any(), any());
+		Mockito.doThrow(AccessDeniedException.class).when(categoryChecker).checkAuthority(any(), any());
 		assertThatThrownBy(
 			() -> cardSimulationService.simulateScore(Id.generateNextId(), Id.generateNextId(), 100)).isInstanceOf(
 			AccessDeniedException.class);
@@ -68,15 +70,21 @@ class CardSimulationServiceTest {
 	@Test
 	@DisplayName("simulateScore 정상 응답 테스트")
 	void scoreResponseTest() {
-		List<Card> testData = new CardDataFactory().createTestData();
-		Mockito.doReturn(Optional.of(Category.builder().build()))
-			.when(categoryRepository)
-			.findByCategoryIdAndMemberId(any(), any());
-		Mockito.doReturn(testData.subList(0, 3)).when(cardRepository).findCardByCategoryIdScoreAsc(any(), anyInt());
-		final int limit = 3;
+		Id memberId = Id.generateNextId();
+		Id categoryId = Id.generateNextId();
+		List<Card> testData = List.of(
+			CardTestHelper.genOxCard(memberId, categoryId, Id.generateNextId()),
+			CardTestHelper.genOxCard(memberId, categoryId, Id.generateNextId()),
+			CardTestHelper.genOxCard(memberId, categoryId, Id.generateNextId()),
+			CardTestHelper.genOxCard(memberId, categoryId, Id.generateNextId())
+		);
+		Mockito.doReturn(CategoryTestHelper.generateUnSharedCategory("title", memberId, categoryId))
+			.when(categoryChecker).checkAuthority(any(), any());
+		Mockito.doReturn(testData).when(cardRepository).findCardByCategoryIdScoreAsc(any(), anyInt());
+		final int limit = 4;
 
 		List<CardResponseDto> scores = cardSimulationService.simulateScore(Id.generateNextId(), Id.generateNextId(),
 			limit);
-		assertThat(scores).doesNotHaveDuplicates().hasSize(3);
+		assertThat(scores).doesNotHaveDuplicates().hasSize(4);
 	}
 }

--- a/src/test/java/com/almondia/meca/helper/CardTestHelper.java
+++ b/src/test/java/com/almondia/meca/helper/CardTestHelper.java
@@ -27,4 +27,20 @@ public class CardTestHelper {
 			.isDeleted(false)
 			.build();
 	}
+
+	public static OxCard genDeletedOxCard(Id memberId, Id categoryId, Id cardId) {
+		return OxCard.builder()
+			.cardId(cardId)
+			.categoryId(categoryId)
+			.memberId(memberId)
+			.title(new Title("title"))
+			.description(new Description("description"))
+			.question(new Question("question"))
+			.oxAnswer(OxAnswer.O)
+			.cardType(CardType.OX_QUIZ)
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.isDeleted(true)
+			.build();
+	}
 }


### PR DESCRIPTION
## 요약

- 테스트 전용 팩토리 메서드 추가
- 삭제된 카드는 쿼리에 포함시키지 않도록 수정