### PR TITLE
feat/#141: 카드 히스토리 페이징 조회 추가

### DIFF
--- a/src/main/java/com/almondia/meca/cardhistory/application/CardHistoryService.java
+++ b/src/main/java/com/almondia/meca/cardhistory/application/CardHistoryService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.almondia.meca.card.domain.repository.CardRepository;
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
 import com.almondia.meca.cardhistory.domain.entity.CardHistory;
 import com.almondia.meca.cardhistory.domain.repository.CardHistoryRepository;
@@ -35,13 +35,13 @@ public class CardHistoryService {
 	}
 
 	@Transactional(readOnly = true)
-	public CursorPage<CardHistoryDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize,
+	public CursorPage<CardHistoryResponseDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize,
 		Id lastCardHistoryId) {
 		return cardHistoryRepository.findCardHistoriesByCardId(cardId, pageSize, lastCardHistoryId);
 	}
 
 	@Transactional(readOnly = true)
-	public CursorPage<CardHistoryDto> findCardHistoriesByCategoryId(@NonNull Id categoryId, int pageSize,
+	public CursorPage<CardHistoryResponseDto> findCardHistoriesByCategoryId(@NonNull Id categoryId, int pageSize,
 		Id lastCardHistoryId) {
 		return cardHistoryRepository.findCardHistoriesByCategoryId(categoryId, pageSize, lastCardHistoryId);
 	}
@@ -49,13 +49,13 @@ public class CardHistoryService {
 	private List<CardHistory> getCardHistories(SaveRequestCardHistoryDto saveRequestCardHistoryDto,
 		Map<Id, List<Id>> categoryIdsByCardId) {
 		List<CardHistory> cardHistories = new ArrayList<>();
-		for (CardHistoryDto cardHistoryDto : saveRequestCardHistoryDto.getCardHistories()) {
+		for (CardHistoryResponseDto cardHistoryResponseDto : saveRequestCardHistoryDto.getCardHistories()) {
 			CardHistory cardHistory = CardHistory.builder()
 				.cardHistoryId(Id.generateNextId())
-				.cardId(cardHistoryDto.getCardId())
-				.categoryId(categoryIdsByCardId.get(cardHistoryDto.getCardId()).get(0))
-				.userAnswer(cardHistoryDto.getUserAnswer())
-				.score(cardHistoryDto.getScore())
+				.cardId(cardHistoryResponseDto.getCardId())
+				.categoryId(categoryIdsByCardId.get(cardHistoryResponseDto.getCardId()).get(0))
+				.userAnswer(cardHistoryResponseDto.getUserAnswer())
+				.score(cardHistoryResponseDto.getScore())
 				.build();
 			cardHistories.add(cardHistory);
 		}
@@ -64,7 +64,7 @@ public class CardHistoryService {
 
 	private Map<Id, List<Id>> checkAuthority(SaveRequestCardHistoryDto saveRequestCardHistoryDto, Id memberId) {
 		List<Id> cardIds = saveRequestCardHistoryDto.getCardHistories().stream()
-			.map(CardHistoryDto::getCardId)
+			.map(CardHistoryResponseDto::getCardId)
 			.collect(Collectors.toList());
 		Map<Id, List<Id>> categoryIdsByCardId = cardRepository.findMapByListOfCardIdAndMemberId(cardIds, memberId);
 		long allValuesCount = categoryIdsByCardId.values().stream().mapToLong(Collection::size).sum();

--- a/src/main/java/com/almondia/meca/cardhistory/application/CardHistoryService.java
+++ b/src/main/java/com/almondia/meca/cardhistory/application/CardHistoryService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +15,7 @@ import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
 import com.almondia.meca.cardhistory.domain.entity.CardHistory;
 import com.almondia.meca.cardhistory.domain.repository.CardHistoryRepository;
+import com.almondia.meca.common.controller.dto.CursorPage;
 import com.almondia.meca.common.domain.vo.Id;
 
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,12 @@ public class CardHistoryService {
 		Map<Id, List<Id>> categoryIdsByCardId = checkAuthority(saveRequestCardHistoryDto, memberId);
 		List<CardHistory> cardHistories = getCardHistories(saveRequestCardHistoryDto, categoryIdsByCardId);
 		cardHistoryRepository.saveAll(cardHistories);
+	}
+
+	@Transactional(readOnly = true)
+	public CursorPage<CardHistoryDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize,
+		Id lastCardHistoryId) {
+		return cardHistoryRepository.findCardHistoriesByCardId(cardId, pageSize, lastCardHistoryId);
 	}
 
 	private List<CardHistory> getCardHistories(SaveRequestCardHistoryDto saveRequestCardHistoryDto,

--- a/src/main/java/com/almondia/meca/cardhistory/application/CardHistoryService.java
+++ b/src/main/java/com/almondia/meca/cardhistory/application/CardHistoryService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.almondia.meca.card.domain.repository.CardRepository;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryRequestDto;
 import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
 import com.almondia.meca.cardhistory.domain.entity.CardHistory;
@@ -49,7 +50,7 @@ public class CardHistoryService {
 	private List<CardHistory> getCardHistories(SaveRequestCardHistoryDto saveRequestCardHistoryDto,
 		Map<Id, List<Id>> categoryIdsByCardId) {
 		List<CardHistory> cardHistories = new ArrayList<>();
-		for (CardHistoryResponseDto cardHistoryResponseDto : saveRequestCardHistoryDto.getCardHistories()) {
+		for (CardHistoryRequestDto cardHistoryResponseDto : saveRequestCardHistoryDto.getCardHistories()) {
 			CardHistory cardHistory = CardHistory.builder()
 				.cardHistoryId(Id.generateNextId())
 				.cardId(cardHistoryResponseDto.getCardId())
@@ -64,7 +65,7 @@ public class CardHistoryService {
 
 	private Map<Id, List<Id>> checkAuthority(SaveRequestCardHistoryDto saveRequestCardHistoryDto, Id memberId) {
 		List<Id> cardIds = saveRequestCardHistoryDto.getCardHistories().stream()
-			.map(CardHistoryResponseDto::getCardId)
+			.map(CardHistoryRequestDto::getCardId)
 			.collect(Collectors.toList());
 		Map<Id, List<Id>> categoryIdsByCardId = cardRepository.findMapByListOfCardIdAndMemberId(cardIds, memberId);
 		long allValuesCount = categoryIdsByCardId.values().stream().mapToLong(Collection::size).sum();

--- a/src/main/java/com/almondia/meca/cardhistory/application/CardHistoryService.java
+++ b/src/main/java/com/almondia/meca/cardhistory/application/CardHistoryService.java
@@ -40,6 +40,12 @@ public class CardHistoryService {
 		return cardHistoryRepository.findCardHistoriesByCardId(cardId, pageSize, lastCardHistoryId);
 	}
 
+	@Transactional(readOnly = true)
+	public CursorPage<CardHistoryDto> findCardHistoriesByCategoryId(@NonNull Id categoryId, int pageSize,
+		Id lastCardHistoryId) {
+		return cardHistoryRepository.findCardHistoriesByCategoryId(categoryId, pageSize, lastCardHistoryId);
+	}
+
 	private List<CardHistory> getCardHistories(SaveRequestCardHistoryDto saveRequestCardHistoryDto,
 		Map<Id, List<Id>> categoryIdsByCardId) {
 		List<CardHistory> cardHistories = new ArrayList<>();

--- a/src/main/java/com/almondia/meca/cardhistory/application/helper/CardHistoryFactory.java
+++ b/src/main/java/com/almondia/meca/cardhistory/application/helper/CardHistoryFactory.java
@@ -1,18 +1,18 @@
 package com.almondia.meca.cardhistory.application.helper;
 
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.cardhistory.domain.entity.CardHistory;
 import com.almondia.meca.common.domain.vo.Id;
 
 public class CardHistoryFactory {
 
-	public static CardHistory makeCardHistory(CardHistoryDto cardHistoryDto, Id categoryId) {
+	public static CardHistory makeCardHistory(CardHistoryResponseDto cardHistoryResponseDto, Id categoryId) {
 		return CardHistory.builder()
 			.cardHistoryId(Id.generateNextId())
-			.cardId(cardHistoryDto.getCardId())
+			.cardId(cardHistoryResponseDto.getCardId())
 			.categoryId(categoryId)
-			.userAnswer(cardHistoryDto.getUserAnswer())
-			.score(cardHistoryDto.getScore())
+			.userAnswer(cardHistoryResponseDto.getUserAnswer())
+			.score(cardHistoryResponseDto.getScore())
 			.build();
 	}
 }

--- a/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
@@ -4,13 +4,19 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.almondia.meca.cardhistory.application.CardHistoryService;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
+import com.almondia.meca.common.controller.dto.CursorPage;
+import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.member.domain.entity.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -29,5 +35,16 @@ public class CardHistoryController {
 		@RequestBody SaveRequestCardHistoryDto saveRequestCardHistoryDto) {
 		cardHistoryService.saveHistories(saveRequestCardHistoryDto, member.getMemberId());
 		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@GetMapping("/cards/{cardId}")
+	public ResponseEntity<CursorPage<CardHistoryDto>> findCardHistoriesByCardId(
+		@PathVariable("cardId") Id cardId,
+		@RequestParam(value = "pageSize", defaultValue = "1000") int pageSize,
+		@RequestParam(value = "lastCardHistoryId", required = false) Id lastCardHistoryId
+	) {
+		CursorPage<CardHistoryDto> cursorPage = cardHistoryService.findCardHistoriesByCardId(cardId,
+			pageSize, lastCardHistoryId);
+		return ResponseEntity.ok(cursorPage);
 	}
 }

--- a/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.almondia.meca.cardhistory.application.CardHistoryService;
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
 import com.almondia.meca.common.controller.dto.CursorPage;
 import com.almondia.meca.common.domain.vo.Id;
@@ -38,23 +38,23 @@ public class CardHistoryController {
 	}
 
 	@GetMapping("/cards/{cardId}")
-	public ResponseEntity<CursorPage<CardHistoryDto>> findCardHistoriesByCardId(
+	public ResponseEntity<CursorPage<CardHistoryResponseDto>> findCardHistoriesByCardId(
 		@PathVariable("cardId") Id cardId,
 		@RequestParam(value = "pageSize", defaultValue = "1000") int pageSize,
 		@RequestParam(value = "lastCardHistoryId", required = false) Id lastCardHistoryId
 	) {
-		CursorPage<CardHistoryDto> cursorPage = cardHistoryService.findCardHistoriesByCardId(cardId,
+		CursorPage<CardHistoryResponseDto> cursorPage = cardHistoryService.findCardHistoriesByCardId(cardId,
 			pageSize, lastCardHistoryId);
 		return ResponseEntity.ok(cursorPage);
 	}
 
 	@GetMapping("/categories/{categoryId}")
-	public ResponseEntity<CursorPage<CardHistoryDto>> findCardHistoriesByCategoryId(
+	public ResponseEntity<CursorPage<CardHistoryResponseDto>> findCardHistoriesByCategoryId(
 		@PathVariable("categoryId") Id categoryId,
 		@RequestParam(value = "pageSize", defaultValue = "1000") int pageSize,
 		@RequestParam(value = "lastCardHistoryId", required = false) Id lastCardHistoryId
 	) {
-		CursorPage<CardHistoryDto> cursorPage = cardHistoryService.findCardHistoriesByCategoryId(categoryId,
+		CursorPage<CardHistoryResponseDto> cursorPage = cardHistoryService.findCardHistoriesByCategoryId(categoryId,
 			pageSize, lastCardHistoryId);
 		return ResponseEntity.ok(cursorPage);
 	}

--- a/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
@@ -41,7 +41,7 @@ public class CardHistoryController {
 	public ResponseEntity<CursorPage<CardHistoryResponseDto>> findCardHistoriesByCardId(
 		@PathVariable("cardId") Id cardId,
 		@RequestParam(value = "pageSize", defaultValue = "1000") int pageSize,
-		@RequestParam(value = "lastCardHistoryId", required = false) Id lastCardHistoryId
+		@RequestParam(value = "hasNext", required = false) Id lastCardHistoryId
 	) {
 		CursorPage<CardHistoryResponseDto> cursorPage = cardHistoryService.findCardHistoriesByCardId(cardId,
 			pageSize, lastCardHistoryId);
@@ -52,7 +52,7 @@ public class CardHistoryController {
 	public ResponseEntity<CursorPage<CardHistoryResponseDto>> findCardHistoriesByCategoryId(
 		@PathVariable("categoryId") Id categoryId,
 		@RequestParam(value = "pageSize", defaultValue = "1000") int pageSize,
-		@RequestParam(value = "lastCardHistoryId", required = false) Id lastCardHistoryId
+		@RequestParam(value = "hasNext", required = false) Id lastCardHistoryId
 	) {
 		CursorPage<CardHistoryResponseDto> cursorPage = cardHistoryService.findCardHistoriesByCategoryId(categoryId,
 			pageSize, lastCardHistoryId);

--- a/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/CardHistoryController.java
@@ -47,4 +47,15 @@ public class CardHistoryController {
 			pageSize, lastCardHistoryId);
 		return ResponseEntity.ok(cursorPage);
 	}
+
+	@GetMapping("/categories/{categoryId}")
+	public ResponseEntity<CursorPage<CardHistoryDto>> findCardHistoriesByCategoryId(
+		@PathVariable("categoryId") Id categoryId,
+		@RequestParam(value = "pageSize", defaultValue = "1000") int pageSize,
+		@RequestParam(value = "lastCardHistoryId", required = false) Id lastCardHistoryId
+	) {
+		CursorPage<CardHistoryDto> cursorPage = cardHistoryService.findCardHistoriesByCategoryId(categoryId,
+			pageSize, lastCardHistoryId);
+		return ResponseEntity.ok(cursorPage);
+	}
 }

--- a/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryDto.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryDto.java
@@ -18,6 +18,7 @@ import lombok.ToString;
 @ToString
 public class CardHistoryDto {
 
+	private Id cardHistoryId;
 	private Id cardId;
 	private Answer userAnswer;
 	private Score score;

--- a/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryRequestDto.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryRequestDto.java
@@ -1,0 +1,22 @@
+package com.almondia.meca.cardhistory.controller.dto;
+
+import com.almondia.meca.cardhistory.domain.vo.Answer;
+import com.almondia.meca.cardhistory.domain.vo.Score;
+import com.almondia.meca.common.domain.vo.Id;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class CardHistoryRequestDto {
+
+	private Id cardId;
+	private Answer userAnswer;
+	private Score score;
+}

--- a/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryResponseDto.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryResponseDto.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 @Builder
 @AllArgsConstructor
 @ToString
-public class CardHistoryDto {
+public class CardHistoryResponseDto {
 
 	private Id cardHistoryId;
 	private Id cardId;

--- a/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryResponseDto.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryResponseDto.java
@@ -3,6 +3,7 @@ package com.almondia.meca.cardhistory.controller.dto;
 import com.almondia.meca.cardhistory.domain.vo.Answer;
 import com.almondia.meca.cardhistory.domain.vo.Score;
 import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.member.domain.vo.Name;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,7 +20,12 @@ import lombok.ToString;
 public class CardHistoryResponseDto {
 
 	private Id cardHistoryId;
-	private Id cardId;
+	private Id memberId;
+	private Name name;
 	private Answer userAnswer;
 	private Score score;
+	private Id categoryId;
+	private com.almondia.meca.category.domain.vo.Title categoryTitle;
+	private Id cardId;
+	private com.almondia.meca.card.domain.vo.Title cardTitle;
 }

--- a/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryResponseDto.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/dto/CardHistoryResponseDto.java
@@ -1,5 +1,7 @@
 package com.almondia.meca.cardhistory.controller.dto;
 
+import java.time.LocalDateTime;
+
 import com.almondia.meca.cardhistory.domain.vo.Answer;
 import com.almondia.meca.cardhistory.domain.vo.Score;
 import com.almondia.meca.common.domain.vo.Id;
@@ -28,4 +30,5 @@ public class CardHistoryResponseDto {
 	private com.almondia.meca.category.domain.vo.Title categoryTitle;
 	private Id cardId;
 	private com.almondia.meca.card.domain.vo.Title cardTitle;
+	private LocalDateTime createdAt;
 }

--- a/src/main/java/com/almondia/meca/cardhistory/controller/dto/SaveRequestCardHistoryDto.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/dto/SaveRequestCardHistoryDto.java
@@ -14,6 +14,6 @@ import lombok.ToString;
 @ToString
 public class SaveRequestCardHistoryDto {
 
-	private List<CardHistoryDto> cardHistories;
+	private List<CardHistoryResponseDto> cardHistories;
 
 }

--- a/src/main/java/com/almondia/meca/cardhistory/controller/dto/SaveRequestCardHistoryDto.java
+++ b/src/main/java/com/almondia/meca/cardhistory/controller/dto/SaveRequestCardHistoryDto.java
@@ -14,6 +14,6 @@ import lombok.ToString;
 @ToString
 public class SaveRequestCardHistoryDto {
 
-	private List<CardHistoryResponseDto> cardHistories;
+	private List<CardHistoryRequestDto> cardHistories;
 
 }

--- a/src/main/java/com/almondia/meca/cardhistory/domain/repository/CardHistoryRepository.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/repository/CardHistoryRepository.java
@@ -6,9 +6,10 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.almondia.meca.cardhistory.domain.entity.CardHistory;
+import com.almondia.meca.cardhistory.infra.querydsl.CardHistoryQueryDslRepository;
 import com.almondia.meca.common.domain.vo.Id;
 
-public interface CardHistoryRepository extends JpaRepository<CardHistory, Id> {
+public interface CardHistoryRepository extends JpaRepository<CardHistory, Id>, CardHistoryQueryDslRepository {
 	List<CardHistory> findByCardId(Id cardId);
 
 	List<CardHistory> findByCardIdInAndIsDeleted(Collection<Id> cardIds, boolean isDeleted);

--- a/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepository.java
+++ b/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepository.java
@@ -1,0 +1,12 @@
+package com.almondia.meca.cardhistory.infra.querydsl;
+
+import org.springframework.lang.NonNull;
+
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.common.controller.dto.CursorPage;
+import com.almondia.meca.common.domain.vo.Id;
+
+public interface CardHistoryQueryDslRepository {
+
+	CursorPage<CardHistoryDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize, Id lastCardHistoryId);
+}

--- a/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepository.java
+++ b/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepository.java
@@ -2,14 +2,15 @@ package com.almondia.meca.cardhistory.infra.querydsl;
 
 import org.springframework.lang.NonNull;
 
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.common.controller.dto.CursorPage;
 import com.almondia.meca.common.domain.vo.Id;
 
 public interface CardHistoryQueryDslRepository {
 
-	CursorPage<CardHistoryDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize, Id lastCardHistoryId);
+	CursorPage<CardHistoryResponseDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize,
+		Id lastCardHistoryId);
 
-	CursorPage<CardHistoryDto> findCardHistoriesByCategoryId(@NonNull Id categoryId, int pageSize,
+	CursorPage<CardHistoryResponseDto> findCardHistoriesByCategoryId(@NonNull Id categoryId, int pageSize,
 		Id lastCardHistoryId);
 }

--- a/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepository.java
+++ b/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepository.java
@@ -9,4 +9,7 @@ import com.almondia.meca.common.domain.vo.Id;
 public interface CardHistoryQueryDslRepository {
 
 	CursorPage<CardHistoryDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize, Id lastCardHistoryId);
+
+	CursorPage<CardHistoryDto> findCardHistoriesByCategoryId(@NonNull Id categoryId, int pageSize,
+		Id lastCardHistoryId);
 }

--- a/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
@@ -47,7 +47,8 @@ public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRep
 					category.categoryId,
 					category.title,
 					cardHistory.cardId,
-					card.title
+					card.title,
+					cardHistory.createdAt
 				))
 			.from(cardHistory)
 			.innerJoin(card)
@@ -96,7 +97,8 @@ public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRep
 					category.categoryId,
 					category.title,
 					cardHistory.cardId,
-					card.title
+					card.title,
+					cardHistory.createdAt
 				))
 			.from(cardHistory)
 			.innerJoin(card)

--- a/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
@@ -6,7 +6,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.cardhistory.domain.entity.QCardHistory;
 import com.almondia.meca.common.controller.dto.CursorPage;
 import com.almondia.meca.common.domain.vo.Id;
@@ -26,17 +26,18 @@ public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRep
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public CursorPage<CardHistoryDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize,
+	public CursorPage<CardHistoryResponseDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize,
 		Id lastCardHistoryId) {
 		Assert.isTrue(pageSize >= 0, "pageSize must be greater than or equal to 0");
 		Assert.isTrue(pageSize <= 1000, "pageSize must be less than or equal to 1000");
 
-		List<CardHistoryDto> contents = jpaQueryFactory.select(Projections.constructor(CardHistoryDto.class,
-				cardHistory.cardHistoryId,
-				cardHistory.cardId,
-				cardHistory.userAnswer,
-				cardHistory.score
-			))
+		List<CardHistoryResponseDto> contents = jpaQueryFactory.select(
+				Projections.constructor(CardHistoryResponseDto.class,
+					cardHistory.cardHistoryId,
+					cardHistory.cardId,
+					cardHistory.userAnswer,
+					cardHistory.score
+				))
 			.from(cardHistory)
 			.where(
 				cardHistory.cardId.eq(cardId),
@@ -56,17 +57,18 @@ public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRep
 	}
 
 	@Override
-	public CursorPage<CardHistoryDto> findCardHistoriesByCategoryId(@NonNull Id categoryId, int pageSize,
+	public CursorPage<CardHistoryResponseDto> findCardHistoriesByCategoryId(@NonNull Id categoryId, int pageSize,
 		Id lastCardHistoryId) {
 		Assert.isTrue(pageSize >= 0, "pageSize must be greater than or equal to 0");
 		Assert.isTrue(pageSize <= 1000, "pageSize must be less than or equal to 1000");
 
-		List<CardHistoryDto> contents = jpaQueryFactory.select(Projections.constructor(CardHistoryDto.class,
-				cardHistory.cardHistoryId,
-				cardHistory.cardId,
-				cardHistory.userAnswer,
-				cardHistory.score
-			))
+		List<CardHistoryResponseDto> contents = jpaQueryFactory.select(
+				Projections.constructor(CardHistoryResponseDto.class,
+					cardHistory.cardHistoryId,
+					cardHistory.cardId,
+					cardHistory.userAnswer,
+					cardHistory.score
+				))
 			.from(cardHistory)
 			.where(
 				cardHistory.categoryId.eq(categoryId),

--- a/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
 
 import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
 import com.almondia.meca.cardhistory.domain.entity.QCardHistory;
@@ -27,7 +28,8 @@ public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRep
 	@Override
 	public CursorPage<CardHistoryDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize,
 		Id lastCardHistoryId) {
-		assert pageSize <= 1000 : "pageSize should be less than or equal to 1000";
+		Assert.isTrue(pageSize >= 0, "pageSize must be greater than or equal to 0");
+		Assert.isTrue(pageSize <= 1000, "pageSize must be less than or equal to 1000");
 
 		List<CardHistoryDto> contents = jpaQueryFactory.select(Projections.constructor(CardHistoryDto.class,
 				cardHistory.cardId,

--- a/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
@@ -6,11 +6,14 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
+import com.almondia.meca.card.domain.entity.QCard;
 import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.cardhistory.domain.entity.QCardHistory;
+import com.almondia.meca.category.domain.entity.QCategory;
 import com.almondia.meca.common.controller.dto.CursorPage;
 import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.common.infra.querydsl.SortOrder;
+import com.almondia.meca.member.domain.entity.QMember;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -22,6 +25,9 @@ import lombok.RequiredArgsConstructor;
 public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRepository {
 
 	private static final QCardHistory cardHistory = QCardHistory.cardHistory;
+	private static final QCard card = QCard.card;
+	private static final QCategory category = QCategory.category;
+	private static final QMember member = QMember.member;
 
 	private final JPAQueryFactory jpaQueryFactory;
 
@@ -34,13 +40,31 @@ public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRep
 		List<CardHistoryResponseDto> contents = jpaQueryFactory.select(
 				Projections.constructor(CardHistoryResponseDto.class,
 					cardHistory.cardHistoryId,
-					cardHistory.cardId,
+					member.memberId,
+					member.name,
 					cardHistory.userAnswer,
-					cardHistory.score
+					cardHistory.score,
+					category.categoryId,
+					category.title,
+					cardHistory.cardId,
+					card.title
 				))
 			.from(cardHistory)
+			.innerJoin(card)
+			.on(
+				cardHistory.cardId.eq(card.cardId),
+				card.isDeleted.eq(false),
+				card.cardId.eq(cardId))
+			.innerJoin(category)
+			.on(
+				card.categoryId.eq(category.categoryId),
+				category.isDeleted.eq(false))
+			.innerJoin(member)
+			.on(
+				category.memberId.eq(member.memberId),
+				member.isDeleted.eq(false)
+			)
 			.where(
-				cardHistory.cardId.eq(cardId),
 				cardHistory.isDeleted.eq(false),
 				lessOrEqCardHistoryId(lastCardHistoryId))
 			.orderBy(cardHistory.cardHistoryId.uuid.desc())
@@ -65,11 +89,30 @@ public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRep
 		List<CardHistoryResponseDto> contents = jpaQueryFactory.select(
 				Projections.constructor(CardHistoryResponseDto.class,
 					cardHistory.cardHistoryId,
-					cardHistory.cardId,
+					member.memberId,
+					member.name,
 					cardHistory.userAnswer,
-					cardHistory.score
+					cardHistory.score,
+					category.categoryId,
+					category.title,
+					cardHistory.cardId,
+					card.title
 				))
 			.from(cardHistory)
+			.innerJoin(card)
+			.on(
+				cardHistory.cardId.eq(card.cardId),
+				card.isDeleted.eq(false))
+			.innerJoin(category)
+			.on(
+				card.categoryId.eq(category.categoryId),
+				category.isDeleted.eq(false),
+				category.categoryId.eq(categoryId))
+			.innerJoin(member)
+			.on(
+				category.memberId.eq(member.memberId),
+				member.isDeleted.eq(false)
+			)
 			.where(
 				cardHistory.categoryId.eq(categoryId),
 				cardHistory.isDeleted.eq(false),

--- a/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.almondia.meca.cardhistory.infra.querydsl;
+
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Repository;
+
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.domain.entity.QCardHistory;
+import com.almondia.meca.common.controller.dto.CursorPage;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.common.infra.querydsl.SortOrder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRepository {
+
+	private static final QCardHistory cardHistory = QCardHistory.cardHistory;
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public CursorPage<CardHistoryDto> findCardHistoriesByCardId(@NonNull Id cardId, int pageSize,
+		Id lastCardHistoryId) {
+		assert pageSize <= 1000 : "pageSize should be less than or equal to 1000";
+
+		List<CardHistoryDto> contents = jpaQueryFactory.select(Projections.constructor(CardHistoryDto.class,
+				cardHistory.cardId,
+				cardHistory.userAnswer,
+				cardHistory.score
+			))
+			.from(cardHistory)
+			.where(
+				cardHistory.cardId.eq(cardId),
+				cardHistory.isDeleted.eq(false),
+				lessOrEqCardHistoryId(lastCardHistoryId))
+			.orderBy(cardHistory.cardHistoryId.uuid.desc())
+			.limit(pageSize + 1)
+			.fetch();
+
+		Id hasNext = null;
+		if (contents.size() > pageSize) {
+			hasNext = contents.get(pageSize).getCardId();
+			contents.remove(pageSize);
+		}
+
+		return new CursorPage<>(contents, hasNext, pageSize, SortOrder.DESC);
+	}
+
+	private BooleanExpression lessOrEqCardHistoryId(Id lastCardHistoryId) {
+		return lastCardHistoryId == null ? null : cardHistory.cardHistoryId.uuid.loe(lastCardHistoryId.getUuid());
+	}
+}

--- a/src/test/java/com/almondia/meca/cardhistory/application/CardHistoryServiceTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/application/CardHistoryServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Import;
 
 import com.almondia.meca.card.domain.entity.Card;
 import com.almondia.meca.card.domain.repository.CardRepository;
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
 import com.almondia.meca.cardhistory.domain.vo.Answer;
 import com.almondia.meca.cardhistory.domain.vo.Score;
@@ -49,7 +49,7 @@ class CardHistoryServiceTest {
 	@DisplayName("권한 체크 여부 테스트")
 	void checkAuthorityTest() {
 		SaveRequestCardHistoryDto saveRequestCardHistoryDto = new SaveRequestCardHistoryDto(List.of(
-			CardHistoryDto.builder()
+			CardHistoryResponseDto.builder()
 				.cardId(Id.generateNextId())
 				.score(new Score(100))
 				.userAnswer(new Answer("100"))

--- a/src/test/java/com/almondia/meca/cardhistory/application/CardHistoryServiceTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/application/CardHistoryServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Import;
 
 import com.almondia.meca.card.domain.entity.Card;
 import com.almondia.meca.card.domain.repository.CardRepository;
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryRequestDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
 import com.almondia.meca.cardhistory.domain.vo.Answer;
 import com.almondia.meca.cardhistory.domain.vo.Score;
@@ -49,7 +49,7 @@ class CardHistoryServiceTest {
 	@DisplayName("권한 체크 여부 테스트")
 	void checkAuthorityTest() {
 		SaveRequestCardHistoryDto saveRequestCardHistoryDto = new SaveRequestCardHistoryDto(List.of(
-			CardHistoryResponseDto.builder()
+			CardHistoryRequestDto.builder()
 				.cardId(Id.generateNextId())
 				.score(new Score(100))
 				.userAnswer(new Answer("100"))

--- a/src/test/java/com/almondia/meca/cardhistory/application/helper/CardHistoryFactoryTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/application/helper/CardHistoryFactoryTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.cardhistory.domain.entity.CardHistory;
 import com.almondia.meca.cardhistory.domain.vo.Answer;
 import com.almondia.meca.cardhistory.domain.vo.Score;
@@ -19,17 +19,17 @@ class CardHistoryFactoryTest {
 	@Test
 	@DisplayName("dto에서 정상정인 인스턴스 생성하는지 테스트")
 	void shouldGenerateNewInstanceFromDtoTest() {
-		CardHistoryDto cardHistoryDto = CardHistoryDto.builder()
+		CardHistoryResponseDto cardHistoryResponseDto = CardHistoryResponseDto.builder()
 			.cardId(Id.generateNextId())
 			.score(new Score(100))
 			.userAnswer(new Answer("123"))
 			.build();
 		Id categoryId = Id.generateNextId();
-		CardHistory cardHistory = CardHistoryFactory.makeCardHistory(cardHistoryDto, categoryId);
+		CardHistory cardHistory = CardHistoryFactory.makeCardHistory(cardHistoryResponseDto, categoryId);
 		assertThat(cardHistory)
-			.hasFieldOrPropertyWithValue("cardId", cardHistoryDto.getCardId())
-			.hasFieldOrPropertyWithValue("score", cardHistoryDto.getScore())
-			.hasFieldOrPropertyWithValue("userAnswer", cardHistoryDto.getUserAnswer())
+			.hasFieldOrPropertyWithValue("cardId", cardHistoryResponseDto.getCardId())
+			.hasFieldOrPropertyWithValue("score", cardHistoryResponseDto.getScore())
+			.hasFieldOrPropertyWithValue("userAnswer", cardHistoryResponseDto.getUserAnswer())
 			.hasFieldOrPropertyWithValue("categoryId", categoryId);
 
 	}

--- a/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.almondia.meca.cardhistory.application.CardHistoryService;
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
 import com.almondia.meca.cardhistory.domain.vo.Answer;
 import com.almondia.meca.cardhistory.domain.vo.Score;
@@ -70,7 +70,7 @@ class CardHistoryControllerTest {
 		@DisplayName("정상 응답 테스트")
 		@WithMockMember
 		void shouldReturn200WhenSuccessTest() throws Exception {
-			CardHistoryDto historyDto = CardHistoryDto.builder()
+			CardHistoryResponseDto historyDto = CardHistoryResponseDto.builder()
 				.cardId(Id.generateNextId())
 				.userAnswer(new Answer("answer"))
 				.score(new Score(100))

--- a/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.almondia.meca.cardhistory.application.CardHistoryService;
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryRequestDto;
 import com.almondia.meca.cardhistory.controller.dto.SaveRequestCardHistoryDto;
 import com.almondia.meca.cardhistory.domain.vo.Answer;
 import com.almondia.meca.cardhistory.domain.vo.Score;
@@ -70,7 +70,7 @@ class CardHistoryControllerTest {
 		@DisplayName("정상 응답 테스트")
 		@WithMockMember
 		void shouldReturn200WhenSuccessTest() throws Exception {
-			CardHistoryResponseDto historyDto = CardHistoryResponseDto.builder()
+			CardHistoryRequestDto historyDto = CardHistoryRequestDto.builder()
 				.cardId(Id.generateNextId())
 				.userAnswer(new Answer("answer"))
 				.score(new Score(100))

--- a/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
@@ -1,5 +1,6 @@
 package com.almondia.meca.cardhistory.controller;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -27,7 +29,9 @@ import com.almondia.meca.cardhistory.domain.vo.Answer;
 import com.almondia.meca.cardhistory.domain.vo.Score;
 import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
 import com.almondia.meca.common.configuration.security.filter.JwtAuthenticationFilter;
+import com.almondia.meca.common.controller.dto.CursorPage;
 import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.helper.CardHistoryTestHelper;
 import com.almondia.meca.mock.security.WithMockMember;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -56,7 +60,7 @@ class CardHistoryControllerTest {
 	}
 
 	/**
-	 * 1. 정상 응답 테스트
+	 * 정상 응답 테스트
 	 */
 	@Nested
 	@DisplayName("시뮬레이션 결과 저장 API")
@@ -78,6 +82,28 @@ class CardHistoryControllerTest {
 					.characterEncoding(StandardCharsets.UTF_8)
 					.content(objectMapper.writeValueAsString(saveRequestCardHistoryDto)))
 				.andExpect(status().isCreated());
+		}
+	}
+
+	@Nested
+	@DisplayName("시뮬레이션 결과 조회 API")
+	class FindSimulationCardHistoryTest {
+
+		@Test
+		@DisplayName("정상 응답 테스트")
+		@WithMockMember
+		void shouldReturn200WhenSuccessTest() throws Exception {
+			Mockito.doReturn(CursorPage.builder()
+					.contents(List.of(CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), Id.generateNextId(),
+						Id.generateNextId(), 100)))
+					.hasNext(null)
+					.pageSize(2)
+					.build())
+				.when(cardHistoryService).findCardHistoriesByCardId(any(), anyInt(), any());
+			mockMvc.perform(get("/api/v1/histories/cards/{cardId}?pageSize=2", Id.generateNextId().toString())
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpect(status().isOk());
 		}
 	}
 }

--- a/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/controller/CardHistoryControllerTest.java
@@ -85,6 +85,9 @@ class CardHistoryControllerTest {
 		}
 	}
 
+	/**
+	 * 정상 응답 테스트
+	 */
 	@Nested
 	@DisplayName("시뮬레이션 결과 조회 API")
 	class FindSimulationCardHistoryTest {
@@ -101,6 +104,28 @@ class CardHistoryControllerTest {
 					.build())
 				.when(cardHistoryService).findCardHistoriesByCardId(any(), anyInt(), any());
 			mockMvc.perform(get("/api/v1/histories/cards/{cardId}?pageSize=2", Id.generateNextId().toString())
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding(StandardCharsets.UTF_8))
+				.andExpect(status().isOk());
+		}
+	}
+
+	@Nested
+	@DisplayName("카테고리 기반 카드 히스토리 조회 API")
+	class FindCardHistoryByCategoryIdTest {
+
+		@Test
+		@DisplayName("정상 응답 테스트")
+		@WithMockMember
+		void shouldReturn200WhenSuccessTest() throws Exception {
+			Mockito.doReturn(CursorPage.builder()
+					.contents(List.of(CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), Id.generateNextId(),
+						Id.generateNextId(), 100)))
+					.hasNext(null)
+					.pageSize(2)
+					.build())
+				.when(cardHistoryService).findCardHistoriesByCategoryId(any(), anyInt(), any());
+			mockMvc.perform(get("/api/v1/histories/categories/{categoryId}?pageSize=2", Id.generateNextId().toString())
 					.contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8))
 				.andExpect(status().isOk());

--- a/src/test/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImplTest.java
@@ -1,0 +1,108 @@
+package com.almondia.meca.cardhistory.infra.querydsl;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.domain.entity.CardHistory;
+import com.almondia.meca.cardhistory.domain.repository.CardHistoryRepository;
+import com.almondia.meca.common.configuration.jpa.QueryDslConfiguration;
+import com.almondia.meca.common.controller.dto.CursorPage;
+import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.helper.CardHistoryTestHelper;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QueryDslConfiguration.class})
+class CardHistoryQueryDslRepositoryImplTest {
+
+	@Autowired
+	private EntityManager em;
+
+	@Autowired
+	private CardHistoryRepository cardHistoryRepository;
+
+	/**
+	 * 삭제된 카드 히스토리는 조회되면 안된다
+	 * 요청 pageSize는 1000이하만 가능하다
+	 * lastCardHistoryId가 null이 아니면 해당 인덱스부터 조회한다
+	 */
+	@Nested
+	@DisplayName("FindCardHistoriesByCardId 메서드 테스트")
+	class FindCardHistoriesByCardId {
+
+		@Test
+		@DisplayName("삭제된 카드 히스토리는 조회되면 안된다")
+		void shouldNotFindDeletedCardHistoryTest() {
+			// given
+			Id categoryId = Id.generateNextId();
+			Id cardId = Id.generateNextId();
+			CardHistory cardHistory = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId, categoryId,
+				10);
+			cardHistory.delete();
+			em.persist(cardHistory);
+
+			// when
+			CursorPage<CardHistoryDto> result = cardHistoryRepository.findCardHistoriesByCardId(cardId,
+				10, null);
+
+			// then
+			assertThat(result.getContents()).isEmpty();
+			assertThat(result.getHasNext()).isNull();
+		}
+
+		@Test
+		@DisplayName("요청 pageSize는 1000이하만 가능하다")
+		void shouldNotFindCardHistoryWhenPageSizeIsOver1000Test() {
+			// given
+			Id categoryId = Id.generateNextId();
+			Id cardId = Id.generateNextId();
+			CardHistory cardHistory = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId, categoryId,
+				10);
+			em.persist(cardHistory);
+
+			// expect
+			assertThatThrownBy(() -> cardHistoryRepository.findCardHistoriesByCardId(cardId, 1001, null))
+				.isInstanceOf(AssertionError.class);
+		}
+
+		@Test
+		@DisplayName("lastCardHistoryId가 null이 아니면 해당 인덱스부터 조회한다")
+		void shouldFindCardHistoryFromLastCardHistoryIdTest() {
+			// given
+			Id categoryId = Id.generateNextId();
+			Id cardId = Id.generateNextId();
+			CardHistory cardHistory1 = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId,
+				categoryId,
+				10);
+			CardHistory cardHistory2 = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId,
+				categoryId,
+				10);
+			CardHistory cardHistory3 = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId,
+				categoryId,
+				10);
+			em.persist(cardHistory1);
+			em.persist(cardHistory2);
+			em.persist(cardHistory3);
+
+			// when
+			CursorPage<CardHistoryDto> result = cardHistoryRepository.findCardHistoriesByCardId(cardId,
+				10, cardHistory2.getCardHistoryId());
+
+			// then
+			assertThat(result.getContents()).hasSize(2);
+			assertThat(result.getHasNext()).isNull();
+		}
+
+	}
+
+}

--- a/src/test/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImplTest.java
@@ -122,4 +122,92 @@ class CardHistoryQueryDslRepositoryImplTest {
 
 	}
 
+	/**
+	 * 삭제된 카드 히스토리는 조회되면 안된다
+	 * 요청 pageSize는 1000이하만 가능하다
+	 * 요청 pageSize는 0이상이어야 한다
+	 * lastCardHistoryId가 null이 아니면 해당 인덱스부터 조회
+	 */
+	@Nested
+	@DisplayName("FindCardHistoriesByCardIdAndCategoryId 메서드 테스트")
+	class FindCardHistoriesByCardIdAndCategoryId {
+
+		@Test
+		@DisplayName("삭제된 카드 히스토리는 조회되면 안된다")
+		void shouldNotFindDeletedCardHistoryTest() {
+			// given
+			Id categoryId = Id.generateNextId();
+			Id cardId = Id.generateNextId();
+			CardHistory cardHistory = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId, categoryId,
+				10);
+			cardHistory.delete();
+			em.persist(cardHistory);
+
+			// when
+			CursorPage<CardHistoryDto> result = cardHistoryRepository.findCardHistoriesByCategoryId(categoryId,
+				10, null);
+
+			// then
+			assertThat(result.getContents()).isEmpty();
+			assertThat(result.getHasNext()).isNull();
+		}
+
+		@Test
+		@DisplayName("요청 pageSize는 1000이하만 가능하다")
+		void shouldNotFindCardHistoryWhenPageSizeIsOver1000Test() {
+			// given
+			Id categoryId = Id.generateNextId();
+			Id cardId = Id.generateNextId();
+			CardHistory cardHistory = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId, categoryId,
+				10);
+			em.persist(cardHistory);
+
+			// expect
+			assertThatThrownBy(() -> cardHistoryRepository.findCardHistoriesByCategoryId(categoryId, 1001, null))
+				.isInstanceOf(InvalidDataAccessApiUsageException.class);
+		}
+
+		@Test
+		@DisplayName("요청 pageSize는 0이상이어야 한다")
+		void shouldNotFindCardHistoryWhenPageSizeIsUnder0Test() {
+			// given
+			Id categoryId = Id.generateNextId();
+			Id cardId = Id.generateNextId();
+			CardHistory cardHistory = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId, categoryId,
+				10);
+			em.persist(cardHistory);
+
+			// expect
+			assertThatThrownBy(() -> cardHistoryRepository.findCardHistoriesByCategoryId(categoryId, -1, null))
+				.isInstanceOf(InvalidDataAccessApiUsageException.class);
+		}
+
+		@Test
+		@DisplayName("lastCardHistoryId가 null이 아니면 해당 인덱스부터 조회")
+		void shouldFindCardHistoryFromLastCardHistoryIdTest() {
+			// given
+			Id categoryId = Id.generateNextId();
+			Id cardId = Id.generateNextId();
+			CardHistory cardHistory1 = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId,
+				categoryId,
+				10);
+			CardHistory cardHistory2 = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId,
+				categoryId,
+				10);
+			CardHistory cardHistory3 = CardHistoryTestHelper.generateCardHistory(Id.generateNextId(), cardId,
+				categoryId,
+				10);
+			em.persist(cardHistory1);
+			em.persist(cardHistory2);
+			em.persist(cardHistory3);
+
+			// when
+			CursorPage<CardHistoryDto> result = cardHistoryRepository.findCardHistoriesByCategoryId(categoryId,
+				10, cardHistory2.getCardHistoryId());
+
+			// then
+			assertThat(result.getContents()).hasSize(2);
+			assertThat(result.getHasNext()).isNull();
+		}
+	}
 }

--- a/src/test/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImplTest.java
@@ -13,7 +13,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 
-import com.almondia.meca.cardhistory.controller.dto.CardHistoryDto;
+import com.almondia.meca.cardhistory.controller.dto.CardHistoryResponseDto;
 import com.almondia.meca.cardhistory.domain.entity.CardHistory;
 import com.almondia.meca.cardhistory.domain.repository.CardHistoryRepository;
 import com.almondia.meca.common.configuration.jpa.QueryDslConfiguration;
@@ -54,7 +54,7 @@ class CardHistoryQueryDslRepositoryImplTest {
 			em.persist(cardHistory);
 
 			// when
-			CursorPage<CardHistoryDto> result = cardHistoryRepository.findCardHistoriesByCardId(cardId,
+			CursorPage<CardHistoryResponseDto> result = cardHistoryRepository.findCardHistoriesByCardId(cardId,
 				10, null);
 
 			// then
@@ -112,7 +112,7 @@ class CardHistoryQueryDslRepositoryImplTest {
 			em.persist(cardHistory3);
 
 			// when
-			CursorPage<CardHistoryDto> result = cardHistoryRepository.findCardHistoriesByCardId(cardId,
+			CursorPage<CardHistoryResponseDto> result = cardHistoryRepository.findCardHistoriesByCardId(cardId,
 				10, cardHistory2.getCardHistoryId());
 
 			// then
@@ -144,7 +144,7 @@ class CardHistoryQueryDslRepositoryImplTest {
 			em.persist(cardHistory);
 
 			// when
-			CursorPage<CardHistoryDto> result = cardHistoryRepository.findCardHistoriesByCategoryId(categoryId,
+			CursorPage<CardHistoryResponseDto> result = cardHistoryRepository.findCardHistoriesByCategoryId(categoryId,
 				10, null);
 
 			// then
@@ -202,7 +202,7 @@ class CardHistoryQueryDslRepositoryImplTest {
 			em.persist(cardHistory3);
 
 			// when
-			CursorPage<CardHistoryDto> result = cardHistoryRepository.findCardHistoriesByCategoryId(categoryId,
+			CursorPage<CardHistoryResponseDto> result = cardHistoryRepository.findCardHistoriesByCategoryId(categoryId,
 				10, cardHistory2.getCardHistoryId());
 
 			// then


### PR DESCRIPTION
## 요약

- 카드 히스토리 페이징 조회 가능(카드별, 카테고리별)
- CardHistoryDto -> CardRequestDto와 CardResponseDto로 분리
- URI: api/v1/histories/categories/{categoryId}, api/v1/histories/cards/{cardId}