### PR TITLE
refactor/#145: 시뮬레이션 서비스 수정

### DIFF
--- a/src/main/java/com/almondia/meca/card/application/CardSimulationService.java
+++ b/src/main/java/com/almondia/meca/card/application/CardSimulationService.java
@@ -3,6 +3,7 @@ package com.almondia.meca.card.application;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,7 +13,8 @@ import com.almondia.meca.card.domain.entity.Card;
 import com.almondia.meca.card.domain.repository.CardRepository;
 import com.almondia.meca.card.domain.service.CardPicker;
 import com.almondia.meca.card.domain.service.RandomCardPicker;
-import com.almondia.meca.category.domain.service.CategoryChecker;
+import com.almondia.meca.category.domain.entity.Category;
+import com.almondia.meca.category.domain.repository.CategoryRepository;
 import com.almondia.meca.common.domain.vo.Id;
 
 import lombok.RequiredArgsConstructor;
@@ -21,22 +23,30 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CardSimulationService {
 
-	private final CategoryChecker categoryChecker;
 	private final CardRepository cardRepository;
+	private final CategoryRepository categoryRepository;
 
 	@Transactional(readOnly = true)
 	public List<CardResponseDto> simulateRandom(Id categoryId, Id memberId, int limit) {
-		categoryChecker.checkAuthority(categoryId, memberId);
-		List<Card> cards = cardRepository.findByCategoryIdAndIsDeleted(categoryId, false);
+		Category category = categoryRepository.findByCategoryIdAndIsDeleted(categoryId, false)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다"));
 		CardPicker cardPicker = new RandomCardPicker();
-		List<Card> pick = cardPicker.pick(cards, limit);
-		return pick.stream().map(CardMapper::cardToDto).collect(Collectors.toList());
+		if (category.isMyCategory(memberId) || (!category.isMyCategory(memberId) && category.isShared())) {
+			List<Card> cards = cardRepository.findByCategoryIdAndIsDeleted(categoryId, false);
+			List<Card> pick = cardPicker.pick(cards, limit);
+			return pick.stream().map(CardMapper::cardToDto).collect(Collectors.toList());
+		}
+		throw new AccessDeniedException("해당 카테고리는 접근할 수 없는 카테고리입니다");
 	}
 
 	@Transactional(readOnly = true)
 	public List<CardResponseDto> simulateScore(Id categoryId, Id memberId, int limit) {
-		categoryChecker.checkAuthority(categoryId, memberId);
-		List<Card> cards = cardRepository.findCardByCategoryIdScoreAsc(categoryId, limit);
-		return cards.stream().map(CardMapper::cardToDto).collect(Collectors.toList());
+		Category category = categoryRepository.findByCategoryIdAndIsDeleted(categoryId, false)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다"));
+		if (category.isMyCategory(memberId) || (!category.isMyCategory(memberId) && category.isShared())) {
+			List<Card> cards = cardRepository.findCardByCategoryIdScoreAsc(categoryId, limit);
+			return cards.stream().map(CardMapper::cardToDto).collect(Collectors.toList());
+		}
+		throw new AccessDeniedException("해당 카테고리는 접근할 수 없는 카테고리입니다");
 	}
 }

--- a/src/main/java/com/almondia/meca/category/domain/entity/Category.java
+++ b/src/main/java/com/almondia/meca/category/domain/entity/Category.java
@@ -61,4 +61,8 @@ public class Category extends DateEntity {
 	public void changeThumbnail(Image thumbnail) {
 		this.thumbnail = thumbnail;
 	}
+
+	public boolean isMyCategory(Id memberId) {
+		return this.memberId.equals(memberId);
+	}
 }

--- a/src/main/java/com/almondia/meca/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/almondia/meca/category/domain/repository/CategoryRepository.java
@@ -11,4 +11,6 @@ import com.almondia.meca.common.domain.vo.Id;
 public interface CategoryRepository extends JpaRepository<Category, Id>, CategoryQueryDslRepository {
 	Optional<Category> findByCategoryIdAndMemberId(Id categoryId, Id memberId);
 
+	Optional<Category> findByCategoryIdAndIsDeleted(Id categoryId, boolean isDeleted);
+
 }


### PR DESCRIPTION
## 요약

- 본인의 카테고리 뿐만 아니라 외부의 카테고리도 시뮬레이션으로 활용할 수 있음
- 외부의 카테고리를 활용시 shared 카테고리의 카드만 시뮬레이션 가능
- 없는 카테고리 조회시 400, unshared의 다른 카테고리 조회시 403