### PR TITLE
refactor/#147: rest docs 적용

### DIFF
--- a/asciidoc.gradle
+++ b/asciidoc.gradle
@@ -1,0 +1,49 @@
+configurations {
+    asciidoctorExtensions
+}
+
+// 변수 선언
+ext {
+    snippetsDir = file('build/generated-snippets') // rest-docs 스니펫 위치 설정
+}
+
+dependencies {
+    // asciidoc
+    // 1.build/generated-snippets 에 생긴 .adoc 조각들을 프로젝트 내의 .adoc 파일에서 읽어들일 수 있도록 연동
+    // 2. .adoc 파일을 HTML로 만들어 export 해줌
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor:2.0.6.RELEASE'
+
+    // restdocs-mockmvc의 testCompile 구성 -> mockMvc를 사용해서 snippets 조각들을 뽑아냄
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:2.0.6.RELEASE'
+}
+
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExtensions'
+    dependsOn test
+    sources {
+        include("**/index.adoc", "**/common/*.adoc")
+    }
+    baseDirFollowsSourceDir()
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+// 커스텀 task 선언: asciidoctor 동작에 의존하고 해당 동작 이후 생성된 파일을 복사하는 task
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
+}
+
+tasks.named('test') {
+    // 위에서 작성한 snippetsDir 디렉토리를 test의 output으로 구성하는 설정 -> 스니펫 조각들이 build/generated-snippets로 출력함
+    outputs.dir snippetsDir
+}

--- a/build.gradle
+++ b/build.gradle
@@ -2,75 +2,16 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.9'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.almondia'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
-
 repositories {
     mavenCentral()
 }
 
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-
-    // aws S3
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.429'
-    testImplementation 'io.findify:s3mock_2.13:0.2.6'
-
-    // querydsl
-    implementation 'com.querydsl:querydsl-jpa'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-
-    // json object
-    implementation 'org.json:json:20211205'
-
-    // db
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'com.mysql:mysql-connector-j'
-
-    // lombok
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-    testCompileOnly 'org.projectlombok:lombok:'
-    testAnnotationProcessor 'org.projectlombok:lombok'
-
-    // jwt
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.3'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.3'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.3'
-
-    // webflux
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
-    // ulid-creator
-    implementation group: 'com.github.f4b6a3', name: 'ulid-creator', version: '5.1.0'
-
-    // mock web server
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
-
-    // reactor test
-    testImplementation 'io.projectreactor:reactor-test'
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
-}
-
-clean {
-    delete file('src/main/generated')
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
-}
+apply from: 'asciidoc.gradle'
+apply from: 'default-dependencies.gradle'

--- a/default-dependencies.gradle
+++ b/default-dependencies.gradle
@@ -1,0 +1,66 @@
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+dependencies {
+
+    // spring boot
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // oauth client
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // aws S3
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.429'
+    testImplementation 'io.findify:s3mock_2.13:0.2.6'
+
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+    // json object
+    implementation 'org.json:json:20230227'
+
+    // db
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'com.mysql:mysql-connector-j'
+
+    // lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok:'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.3'
+
+    // webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // ulid-creator
+    implementation group: 'com.github.f4b6a3', name: 'ulid-creator', version: '5.1.0'
+
+    // mock web server
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
+
+    // reactor test
+    testImplementation 'io.projectreactor:reactor-test'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+}
+
+clean {
+    delete file('src/main/generated')
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -8,6 +8,26 @@
 
 include::overview.adoc[]
 
+[[Oauth-API]]
+== OAuth API
+
+[[Oauth-로그인]]
+=== OAuth 로그인
+
+operation::oauth-controller-test/should-return-access-token-response-dto-all-properties-and-response-status-using-camel-case-test[snippets='http-request,path-parameters,request-parameters']
+
+==== HTTP response
+
+처음 로그인시 oauthId로 회원 아이디 생성 응답
+
+include::{snippets}/oauth-controller-test/should-return-access-token-response-dto-all-properties-and-response-status-using-camel-case-test/http-response.adoc[]
+
+로그인시 응답
+
+include::{snippets}/oauth-controller-test/should-return-access-token-and-status200-when-duplicate-login/http-response.adoc[]
+
+operation::oauth-controller-test/should-return-access-token-response-dto-all-properties-and-response-status-using-camel-case-test[snippets='response-fields']
+
 [[Member-API]]
 == Member API
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,22 @@
+= mecastudy rest API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+include::overview.adoc[]
+
+[[Member-API]]
+== Member API
+
+[[Member-개인-프로필-조회]]
+=== Member 개인 프로필 조회
+
+operation::find-my-profile/should-return-member-response-dto-attributes-when-return200-test[snippets='http-request,request-headers,http-response,response-fields']
+
+
+
+
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -63,3 +63,52 @@ operation::update-category-test/should-return200-when-success-update-category-te
 === Category 카테고리 삭제
 
 operation::delete-category-test/should-return-status200-when-success-test[snippets='http-request,path-parameters,http-response']
+
+[[Card-API]]
+== Card API
+
+[[Card-개인-카드-단일-조회]]
+=== Card 개인 카드 단일 조회
+
+operation::search-card-one-test/should-return200ok-and-response-format-test[snippets='http-request,path-parameters,http-response,response-fields']
+
+[[Card-공유-카드-단일-조회]]
+=== Card 공유 카드 단일 조회
+
+operation::find-shared-card-test/should-return200-ok-and-response-format-test[snippets='http-request,path-parameters,http-response,response-fields']
+
+[[Card-카드-페이징-조회]]
+=== Card 카드 페이징 조회
+
+operation::card-cursor-paging-search-test/should-return200-when-success-test[snippets='http-request,path-parameters,request-parameters,http-response,response-fields']
+
+[[Card-공유-카드-페이징-조회]]
+=== Card 공유 카드 페이징 조회
+
+operation::shared-card-cursor-paging-test/should-return200-ok-and-response-format-test[snippets='http-request,path-parameters,request-parameters,http-response,response-fields']
+
+[[Card-카드-시뮬레이션-조회]]
+=== Card 카드 시뮬레이션 조회
+
+operation::simulate-card-test/should-return200-when-success-test[snippets='http-request,path-parameters,http-response,response-fields']
+
+[[Card-카테고리별-카드-조회]]
+=== Card 카테고리별 카드 조회
+
+operation::find-card-count-by-category-test/should-return200ok-and-response-format-test[snippets='http-request,path-parameters,http-response,response-fields']
+
+[[Card-카드-등록]]
+=== Card 카드 등록
+
+operation::save-card-test/should-return201-when-enroll-success-test[snippets='http-request,request-fields,http-response,response-fields']
+
+[[Card-카드-수정]]
+=== Card 카드 수정
+
+operation::update-category-test/should-return200-when-success-update-category-test[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+
+[[Card-카드-삭제]]
+=== Card 카드 삭제
+
+operation::delete-category-test/should-return-status200-when-success-test[snippets='http-request,path-parameters,http-response']
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -8,8 +8,8 @@
 
 include::overview.adoc[]
 
-[[Oauth-API]]
-== OAuth API
+[[Auth-API]]
+== Auth API
 
 [[Oauth-로그인]]
 === OAuth 로그인
@@ -27,6 +27,11 @@ include::{snippets}/oauth-controller-test/should-return-access-token-response-dt
 include::{snippets}/oauth-controller-test/should-return-access-token-and-status200-when-duplicate-login/http-response.adoc[]
 
 operation::oauth-controller-test/should-return-access-token-response-dto-all-properties-and-response-status-using-camel-case-test[snippets='response-fields']
+
+[[Presign-이미지-업로드]]
+=== Presign 이미지 업로드
+
+operation::presign/upload[snippets='http-request,request-parameters,http-response']
 
 [[Member-API]]
 == Member API

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -112,3 +112,20 @@ operation::update-category-test/should-return200-when-success-update-category-te
 
 operation::delete-category-test/should-return-status200-when-success-test[snippets='http-request,path-parameters,http-response']
 
+[[CardHistory-API]]
+== CardHistory API
+
+[[CardHistory-시뮬레이션-카드-히스토리-등록]]
+=== CardHistory 시뮬레이션 카드 히스토리 등록
+
+operation::save-simulation-card-history-test/should-return200-when-success-test[snippets='http-request,request-fields,http-response']
+
+[[CardHistory-카드ID-기반-카드-히스토리-페이징-조회]]
+=== CardHistory 카드ID 기반 카드 히스토리 페이징 조회
+
+operation::find-simulation-card-history-test/should-return200-when-success-test[snippets='http-request,path-parameters,request-parameters,http-response,response-fields']
+
+[[CardHistory-카테고리ID-기반-카드-히스토리-단일-조회]]
+=== CardHistory 카테고리ID 기반 카드 히스토리 단일 조회
+
+operation::find-card-history-by-category-id-test/should-return200-when-success-test[snippets='http-request,path-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -34,9 +34,32 @@ operation::oauth-controller-test/should-return-access-token-response-dto-all-pro
 [[Member-개인-프로필-조회]]
 === Member 개인 프로필 조회
 
-operation::find-my-profile/should-return-member-response-dto-attributes-when-return200-test[snippets='http-request,request-headers,http-response,response-fields']
+operation::find-my-profile/should-return-member-response-dto-attributes-when-return200-test[snippets='http-request,http-response,response-fields']
 
+[[Category-API]]
+== Category API
 
+[[Category-개인-카테고리-페이징-조회]]
+=== Category 개인 카테고리 페이징 조회
 
+operation::offset-paging-category-test/should-return-page-type-when-call-paging-search-test[snippets='http-request,request-parameters,http-response,response-fields']
 
+[[Category-공유-카테고리-페이징-조회]]
+=== Category 공유 카테고리 페이징 조회
 
+operation::search-share-category-test/should-return-status200-and-response-when-success-test[snippets='http-request,request-parameters,http-response,response-fields']
+
+[[Category-카테고리-등록]]
+=== Category 카테고리 등록
+
+operation::save-category-test/should-return201-when-enroll-success-test[snippets='http-request,request-fields,http-response,response-fields']
+
+[[Category-카테고리-수정]]
+=== Category 카테고리 수정
+
+operation::update-category-test/should-return200-when-success-update-category-test[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+
+[[Cateogory-카테고리-삭제]]
+=== Category 카테고리 삭제
+
+operation::delete-category-test/should-return-status200-when-success-test[snippets='http-request,path-parameters,http-response']

--- a/src/docs/asciidoc/overview.adoc
+++ b/src/docs/asciidoc/overview.adoc
@@ -1,0 +1,37 @@
+[[overview]]
+== Overview
+
+[[overview-host]]
+=== Host
+
+|===
+| 환경 | Host
+
+| Production
+| `mecastudy.com`
+|===
+
+[[overview-http-status-codes]]
+=== HTTP status codes
+
+|===
+| 상태 코드 | 설명
+
+| `200 OK`
+| 성공
+
+| `400 Bad Request`
+| 잘못된 요청
+
+| `401 Unauthorized`
+| 비인증 상태
+
+| `403 Forbidden`
+| 권한 거부
+
+| `404 Not Found`
+| 존재하지 않는 요청 리소스
+
+| `500 Internal Server Error`
+| 서버 에러
+|===

--- a/src/main/java/com/almondia/meca/auth/oauth/controller/OauthController.java
+++ b/src/main/java/com/almondia/meca/auth/oauth/controller/OauthController.java
@@ -29,7 +29,7 @@ public class OauthController {
 	private final JwtTokenService jwtTokenService;
 
 	@PostMapping("/login/{registrationId}")
-	public ResponseEntity<AccessTokenResponseDto> getUserInfo(
+	public ResponseEntity<AccessTokenResponseDto> loginUser(
 		@PathVariable("registrationId") String registrationId,
 		@RequestParam("code") String authorizationCode) {
 		HttpStatus statusResponse = HttpStatus.OK;

--- a/src/main/java/com/almondia/meca/card/controller/CardController.java
+++ b/src/main/java/com/almondia/meca/card/controller/CardController.java
@@ -59,6 +59,34 @@ public class CardController {
 	}
 
 	@Secured("ROLE_USER")
+	@DeleteMapping("/{cardId}")
+	public ResponseEntity<String> deleteCard(
+		@AuthenticationPrincipal Member member,
+		@PathVariable(value = "cardId") Id cardId
+	) {
+		cardService.deleteCard(cardId, member.getMemberId());
+		return ResponseEntity.status(HttpStatus.OK).body("");
+	}
+
+	@Secured("ROLE_USER")
+	@GetMapping("/{cardId}/me")
+	public ResponseEntity<CardResponseDto> findCardByCardId(
+		@AuthenticationPrincipal Member member,
+		@PathVariable(value = "cardId") Id cardId
+	) {
+		CardResponseDto responseDto = cardService.findCardById(cardId, member.getMemberId());
+		return ResponseEntity.ok(responseDto);
+	}
+
+	@GetMapping("/{cardId}/share")
+	public ResponseEntity<SharedCardResponseDto> findCardByCardId(
+		@PathVariable(value = "cardId") Id cardId
+	) {
+		SharedCardResponseDto responseDto = cardService.findSharedCard(cardId);
+		return ResponseEntity.ok(responseDto);
+	}
+
+	@Secured("ROLE_USER")
 	@GetMapping("/categories/{categoryId}/me")
 	public ResponseEntity<CursorPage<CardResponseDto>> searchPagingCards(
 		@AuthenticationPrincipal Member member,
@@ -93,24 +121,6 @@ public class CardController {
 	}
 
 	@Secured("ROLE_USER")
-	@GetMapping("/{cardId}/me")
-	public ResponseEntity<CardResponseDto> findCardByCardId(
-		@AuthenticationPrincipal Member member,
-		@PathVariable(value = "cardId") Id cardId
-	) {
-		CardResponseDto responseDto = cardService.findCardById(cardId, member.getMemberId());
-		return ResponseEntity.ok(responseDto);
-	}
-
-	@GetMapping("/{cardId}/share")
-	public ResponseEntity<SharedCardResponseDto> findCardByCardId(
-		@PathVariable(value = "cardId") Id cardId
-	) {
-		SharedCardResponseDto responseDto = cardService.findSharedCard(cardId);
-		return ResponseEntity.ok(responseDto);
-	}
-
-	@Secured("ROLE_USER")
 	@GetMapping("/categories/{categoryId}/simulation")
 	public ResponseEntity<List<CardResponseDto>> findCardByCardIdResponseDto(
 		@AuthenticationPrincipal Member member,
@@ -138,15 +148,5 @@ public class CardController {
 	) {
 		long count = cardService.findCardsCountByCategoryId(categoryId, member.getMemberId());
 		return ResponseEntity.ok(new CardCountResponseDto(count));
-	}
-
-	@Secured("ROLE_USER")
-	@DeleteMapping("/{cardId}")
-	public ResponseEntity<String> deleteCard(
-		@AuthenticationPrincipal Member member,
-		@PathVariable(value = "cardId") Id cardId
-	) {
-		cardService.deleteCard(cardId, member.getMemberId());
-		return ResponseEntity.status(HttpStatus.OK).body("");
 	}
 }

--- a/src/main/java/com/almondia/meca/common/configuration/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/almondia/meca/common/configuration/security/filter/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -22,7 +23,6 @@ import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.member.application.MemberService;
 import com.almondia.meca.member.domain.entity.Member;
 
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 @Component

--- a/src/main/java/com/almondia/meca/member/controller/MemberController.java
+++ b/src/main/java/com/almondia/meca/member/controller/MemberController.java
@@ -22,7 +22,7 @@ public class MemberController {
 
 	@GetMapping("/me")
 	@Secured("ROLE_USER")
-	public ResponseEntity<MemberResponseDto> getMyProfile(@AuthenticationPrincipal Member member) {
+	public ResponseEntity<MemberResponseDto> findMyProfile(@AuthenticationPrincipal Member member) {
 		MemberResponseDto myProfile = memberService.findMyProfile(member.getMemberId());
 		return ResponseEntity.ok(myProfile);
 	}

--- a/src/test/java/com/almondia/meca/asciidocs/ApiDocumentUtils.java
+++ b/src/test/java/com/almondia/meca/asciidocs/ApiDocumentUtils.java
@@ -1,0 +1,22 @@
+package com.almondia.meca.asciidocs;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+public interface ApiDocumentUtils {
+
+	static OperationRequestPreprocessor getDocumentRequest() {
+		return preprocessRequest(
+			modifyUris()
+				.scheme("https")
+				.host("mecastudy.com")
+				.removePort(),
+			prettyPrint());
+	}
+
+	static OperationResponsePreprocessor getDocumentResponse() {
+		return preprocessResponse(prettyPrint());
+	}
+}

--- a/src/test/java/com/almondia/meca/auth/s3/controller/PreSignedControllerTest.java
+++ b/src/test/java/com/almondia/meca/auth/s3/controller/PreSignedControllerTest.java
@@ -1,20 +1,32 @@
 package com.almondia.meca.auth.s3.controller;
 
+import static com.almondia.meca.asciidocs.ApiDocumentUtils.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.net.URL;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
@@ -24,9 +36,14 @@ import com.almondia.meca.common.infra.s3.S3PreSignedUrlRequest;
 import com.almondia.meca.mock.security.WithMockMember;
 
 @WebMvcTest(PreSignedController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith({RestDocumentationExtension.class})
 @Import({JacksonConfiguration.class, WebMvcConfiguration.class})
 class PreSignedControllerTest {
+
+	private static final String jwtToken = "jwt token";
+
+	@Autowired
+	WebApplicationContext context;
 
 	@MockBean
 	JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -34,20 +51,55 @@ class PreSignedControllerTest {
 	@MockBean
 	S3PreSignedUrlRequest s3PreSignedUrlRequest;
 
-	@Autowired
 	MockMvc mockMvc;
+
+	@BeforeEach
+	public void setUp(RestDocumentationContextProvider restDocumentation) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.alwaysDo(print())
+			.apply(documentationConfiguration(restDocumentation))
+			.build();
+	}
 
 	@Test
 	@DisplayName("응답 성공시 Upload PresignedUrl를 리턴해야함")
 	@WithMockMember
 	void successResponseOkAndGetUrlTest() throws Exception {
+		// given
 		URL url = UriComponentsBuilder.fromUriString("https://www.abc.com").build().toUri().toURL();
 		Mockito.doReturn(url).when(s3PreSignedUrlRequest).requestPutPreSignedUrl(any(), any());
-		mockMvc.perform(get("/api/v1/presign/images/upload?purpose=thumbnail&extension=jpg&fileName=abc"))
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/presign/images/upload")
+			.header("Authorization", "Bearer " + jwtToken)
+			.queryParam("purpose", "thumbnail")
+			.queryParam("extension", "jpg")
+			.queryParam("fileName", "abc"));
+
+		// then
+		resultActions
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("url").exists())
 			.andExpect(jsonPath("expirationDate").exists())
-			.andExpect(jsonPath("objectKey").exists());
+			.andExpect(jsonPath("objectKey").exists())
+			.andDo(document(
+				"presign/upload",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Token")
+				),
+				requestParameters(
+					parameterWithName("purpose").description("이미지 용도(thumbnail,profile,card"),
+					parameterWithName("extension").description("파일의 확장자(png,jpeg,jpg,gif"),
+					parameterWithName("fileName").description("파일의 이름")
+				),
+				responseFields(
+					fieldWithPath("url").description("S3에 업로드 요청 가능한 presigned url"),
+					fieldWithPath("expirationDate").description("URL의 만료 시간"),
+					fieldWithPath("objectKey").description("S3에 업로드할 파일의 이름")
+				)
+			));
 	}
 
 	@Test

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -1,7 +1,13 @@
 package com.almondia.meca.card.controller;
 
+import static com.almondia.meca.asciidocs.ApiDocumentUtils.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.snippet.Attributes.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -12,13 +18,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -53,8 +63,14 @@ import com.almondia.meca.mock.security.WithMockMember;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(CardController.class)
+@ExtendWith({RestDocumentationExtension.class})
 @Import({JacksonConfiguration.class})
 class CardControllerTest {
+
+	private static final String jwtToken = "Bearer jwt token";
+
+	@Autowired
+	WebApplicationContext context;
 
 	@MockBean
 	CardService cardService;
@@ -66,21 +82,21 @@ class CardControllerTest {
 	JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@Autowired
-	WebApplicationContext context;
-
-	@Autowired
 	MockMvc mockMvc;
 
 	@Autowired
 	ObjectMapper objectMapper;
 
 	@BeforeEach
-	void before() {
-		mockMvc = MockMvcBuilders.webAppContextSetup(context).alwaysDo(print()).build();
+	public void setUp(RestDocumentationContextProvider restDocumentation) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.alwaysDo(print())
+			.apply(documentationConfiguration(restDocumentation))
+			.build();
 	}
 
 	/**
-	 * 1. 요청 성공시 201을 리턴하고 카드 정보를 반환한다.
+	 * 요청 성공시 201을 리턴하고 카드 정보를 반환한다.
 	 */
 	@Nested
 	@DisplayName("카드 저장 API 테스트")
@@ -89,20 +105,25 @@ class CardControllerTest {
 		@Test
 		@WithMockMember
 		@DisplayName("요청 성공시 201을 리턴하고 카드 정보를 반환한다")
-		void test() throws Exception {
+		void shouldReturn201WhenEnrollSuccessTest() throws Exception {
+			// given
 			SaveCardRequestDto saveCardRequestDto = SaveCardRequestDto.builder()
 				.title(new Title("title"))
 				.question(new Question("hello"))
-				.description(new Description("hello"))
 				.categoryId(Id.generateNextId())
 				.cardType(CardType.OX_QUIZ)
 				.answer(OxAnswer.O.toString())
+				.description(new Description("hello"))
 				.build();
 			Mockito.doReturn(makeResponse()).when(cardService).saveCard(any(), any());
 
-			mockMvc.perform(post("/api/v1/cards").contentType(MediaType.APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(saveCardRequestDto)))
-				.andExpect(status().isCreated())
+			// when
+			ResultActions resultActions = mockMvc.perform(post("/api/v1/cards").contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(saveCardRequestDto))
+				.header("Authorization", jwtToken));
+
+			// then
+			resultActions.andExpect(status().isCreated())
 				.andExpect(jsonPath("cardId").exists())
 				.andExpect(jsonPath("title").exists())
 				.andExpect(jsonPath("memberId").exists())
@@ -113,7 +134,28 @@ class CardControllerTest {
 				.andExpect(jsonPath("createdAt").exists())
 				.andExpect(jsonPath("modifiedAt").exists())
 				.andExpect(jsonPath("title").exists())
-				.andExpect(jsonPath("answer").exists());
+				.andExpect(jsonPath("answer").exists())
+				.andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse(),
+					requestHeaders(headerWithName("Authorization").description("jwt token")), requestFields(
+						fieldWithPath("title").description("카드 제목").attributes(key("constraints").value("2 ~ 40 글자")),
+						fieldWithPath("question").description("카드 질문")
+							.attributes(key("constraints").value("공백 없이 500 글자 이하")),
+						fieldWithPath("description").description("카드 설명")
+							.optional()
+							.attributes(key("constraints").value("2,1000자 이하 글자")),
+						fieldWithPath("categoryId").description("카테고리 아이디"),
+						fieldWithPath("cardType").description("카드 타입")
+							.attributes(key("constraints").value("OX_QUIZ, CHOICE_QUIZ, SHORT_ANSWER_QUIZ")),
+						fieldWithPath("answer").description("카드 정답")),
+					responseFields(fieldWithPath("cardId").description("카드 아이디"),
+						fieldWithPath("title").description("카드 제목"), fieldWithPath("memberId").description("멤버 아이디"),
+						fieldWithPath("question").description("카드 질문"),
+						fieldWithPath("description").description("카드 설명"),
+						fieldWithPath("categoryId").description("카테고리 아이디"),
+						fieldWithPath("cardType").description("카드 타입"),
+						fieldWithPath("createdAt").description("카드 생성일"),
+						fieldWithPath("modifiedAt").description("카드 수정일"), fieldWithPath("title").description("카드 제목"),
+						fieldWithPath("answer").description("카드 정답"))));
 		}
 
 		private CardResponseDto makeResponse() {
@@ -133,7 +175,7 @@ class CardControllerTest {
 	}
 
 	/**
-	 * 1. 성공시 200 응답코드와 리턴해야할 값 검증
+	 * 성공시 200 응답코드와 리턴해야할 값 검증
 	 */
 	@Nested
 	@DisplayName("카드 업데이트 API 테스트")
@@ -143,6 +185,7 @@ class CardControllerTest {
 		@WithMockMember
 		@DisplayName("성공시 200 응답코드와 리턴해야할 값 검증")
 		void shouldReturn200WhenSuccessTest() throws Exception {
+			// given
 			UpdateCardRequestDto requestDto = UpdateCardRequestDto.builder()
 				.title(new Title("title"))
 				.question(new Question("question"))
@@ -151,10 +194,14 @@ class CardControllerTest {
 				.build();
 			Mockito.doReturn(makeResponse()).when(cardService).updateCard(any(), any(), any());
 
-			mockMvc.perform(
-					put("/api/v1/cards/{cardId}", Id.generateNextId().toString()).contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(requestDto)))
-				.andExpect(status().isOk())
+			// when
+			ResultActions resultActions = mockMvc.perform(
+				put("/api/v1/cards/{cardId}", Id.generateNextId().toString()).contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(requestDto))
+					.header("Authorization", jwtToken));
+
+			// then
+			resultActions.andExpect(status().isOk())
 				.andExpect(jsonPath("cardId").exists())
 				.andExpect(jsonPath("title").exists())
 				.andExpect(jsonPath("memberId").exists())
@@ -165,7 +212,29 @@ class CardControllerTest {
 				.andExpect(jsonPath("createdAt").exists())
 				.andExpect(jsonPath("modifiedAt").exists())
 				.andExpect(jsonPath("title").exists())
-				.andExpect(jsonPath("answer").exists());
+				.andExpect(jsonPath("answer").exists())
+				.andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse(),
+					requestHeaders(headerWithName("Authorization").description("jwt token")),
+					pathParameters(parameterWithName("cardId").description("카드 아이디")), requestFields(
+						fieldWithPath("title").description("변경할 카드 제목")
+							.optional()
+							.attributes(key("constraints").value("2 ~ 40 글자")),
+						fieldWithPath("question").description("변경할 카드 질문")
+							.optional()
+							.attributes(key("constraints").value("공백 없이 500 글자 이하")),
+						fieldWithPath("description").description("변경할 카드 설명")
+							.optional()
+							.attributes(key("constraints").value("2,1000자 이하 글자")),
+						fieldWithPath("categoryId").description("변경할 카테고리 아이디").optional()),
+					responseFields(fieldWithPath("cardId").description("카드 아이디"),
+						fieldWithPath("title").description("카드 제목"), fieldWithPath("memberId").description("멤버 아이디"),
+						fieldWithPath("question").description("카드 질문"),
+						fieldWithPath("description").description("카드 설명"),
+						fieldWithPath("categoryId").description("카테고리 아이디"),
+						fieldWithPath("cardType").description("카드 타입"),
+						fieldWithPath("createdAt").description("카드 생성일"),
+						fieldWithPath("modifiedAt").description("카드 수정일"), fieldWithPath("title").description("카드 제목"),
+						fieldWithPath("answer").description("카드 정답"))));
 		}
 
 		private CardResponseDto makeResponse() {
@@ -179,58 +248,13 @@ class CardControllerTest {
 				.answer(OxAnswer.O.name())
 				.description(new Description("hello"))
 				.createdAt(LocalDateTime.now())
-				.modifiedAt(LocalDateTime.now())
+				.modifiedAt(LocalDateTime.now().plusMinutes(20L))
 				.build();
 		}
 	}
 
 	/**
-	 * 1. 성공시 200 응답코드와 리턴해야할 값 검증
-	 */
-	@Nested
-	@DisplayName("카드 커서 페이징 조회 API")
-	class CardCursorPagingSearchTest {
-
-		@Test
-		@WithMockMember
-		void shouldReturn200WhenSuccessTest() throws Exception {
-			List<CardResponseDto> contents = List.of(makeResponse());
-			CardCursorPageWithCategory cardCursorPageWithCategory = new CardCursorPageWithCategory(contents,
-				Id.generateNextId(), 5, SortOrder.DESC);
-			cardCursorPageWithCategory.setCategory(Category.builder()
-				.categoryId(Id.generateNextId())
-				.title(new com.almondia.meca.category.domain.vo.Title("title"))
-				.build());
-			Mockito.doReturn(cardCursorPageWithCategory)
-				.when(cardService)
-				.searchCursorPagingCard(anyInt(), any(), any(), any(), any());
-			mockMvc.perform(
-					get("/api/v1/cards/categories/{categoryId}/me?pageSize=100&sortOrder=desc", Id.generateNextId()))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("contents").exists())
-				.andExpect(jsonPath("pageSize").exists())
-				.andExpect(jsonPath("sortOrder").exists())
-				.andExpect(jsonPath("category").exists());
-		}
-
-		private CardResponseDto makeResponse() {
-			return CardResponseDto.builder()
-				.cardId(Id.generateNextId())
-				.title(new Title("title"))
-				.memberId(Id.generateNextId())
-				.question(new Question("hello"))
-				.categoryId(Id.generateNextId())
-				.cardType(CardType.OX_QUIZ)
-				.answer(OxAnswer.O.name())
-				.description(new Description("hello"))
-				.createdAt(LocalDateTime.now())
-				.modifiedAt(LocalDateTime.now())
-				.build();
-		}
-	}
-
-	/**
-	 * 1. 정상 동작시 200 응답 테스트
+	 * 정상 동작시 200 응답 테스트
 	 */
 	@Nested
 	@DisplayName("카드 삭제 API")
@@ -240,8 +264,18 @@ class CardControllerTest {
 		@DisplayName("정상 동작시 200 응답 테스트")
 		@WithMockMember
 		void shouldReturnOkWhenCallSuccessTest() throws Exception {
-			mockMvc.perform(delete("/api/v1/cards/{cardId}", Id.generateNextId()))
-				.andExpect(status().isOk());
+			// given
+			Id cardId = Id.generateNextId();
+
+			// when
+			ResultActions resultActions = mockMvc.perform(
+				delete("/api/v1/cards/{cardId}", cardId).header("Authorization", jwtToken));
+
+			// then
+			resultActions.andExpect(status().isOk())
+				.andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse(),
+					requestHeaders(headerWithName("Authorization").description("jwt token")),
+					pathParameters(parameterWithName("cardId").description("카드 아이디"))));
 		}
 	}
 
@@ -256,75 +290,44 @@ class CardControllerTest {
 		@WithMockMember
 		@DisplayName("정상 동작시 200 응답 및 응답 포맷 테스트")
 		void shouldReturn200OKAndResponseFormatTest() throws Exception {
+			// given
 			CardResponseDto responseDto = CardResponseDto.builder()
 				.cardId(Id.generateNextId())
 				.memberId(Id.generateNextId())
+				.categoryId(Id.generateNextId())
 				.question(new Question("question"))
 				.cardType(CardType.OX_QUIZ)
 				.answer("O")
 				.description(new Description("hello"))
 				.title(new Title("title1"))
+				.createdAt(LocalDateTime.now())
+				.modifiedAt(LocalDateTime.now())
 				.build();
 			Mockito.doReturn(responseDto).when(cardService).findCardById(any(), any());
-			mockMvc.perform(get("/api/v1/cards/{cardId}/me", Id.generateNextId()))
-				.andExpect(status().isOk())
+
+			// when
+			ResultActions resultActions = mockMvc.perform(
+				get("/api/v1/cards/{cardId}/me", Id.generateNextId()).header("Authorization", jwtToken));
+
+			// then
+			resultActions.andExpect(status().isOk())
 				.andExpect(jsonPath("cardId").exists())
 				.andExpect(jsonPath("question").exists())
 				.andExpect(jsonPath("memberId").exists())
 				.andExpect(jsonPath("cardType").exists())
 				.andExpect(jsonPath("answer").exists())
 				.andExpect(jsonPath("description").exists())
-				.andExpect(jsonPath("title").exists());
-		}
-	}
-
-	/**
-	 *  1. 정상 동작시 200 응답 및 응답 포맷 테스트
-	 */
-	@Nested
-	@DisplayName("카드 시뮬레이션 테스트")
-	class CardSimulationTest {
-
-		@Test
-		@WithMockMember
-		@DisplayName("정상 동작시 200 응답 및 응답 포맷 테스트")
-		void cardSimulationTest() throws Exception {
-			CardResponseDto responseDto = CardResponseDto.builder()
-				.cardId(Id.generateNextId())
-				.memberId(Id.generateNextId())
-				.question(new Question("question"))
-				.cardType(CardType.OX_QUIZ)
-				.answer("O")
-				.description(new Description("hello"))
-				.title(new Title("title1"))
-				.build();
-			Mockito.doReturn(List.of(responseDto)).when(cardSimulationService).simulateRandom(any(), any(), anyInt());
-			mockMvc.perform(
-					get("/api/v1/cards/categories/{categoryId}/simulation?limit=3&algorithm=random", Id.generateNextId()))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$[0].cardId").exists())
-				.andExpect(jsonPath("$[0].memberId").exists())
-				.andExpect(jsonPath("$[0].question").exists())
-				.andExpect(jsonPath("$[0].cardType").exists())
-				.andExpect(jsonPath("$[0].answer").exists())
-				.andExpect(jsonPath("$[0].description").exists())
-				.andExpect(jsonPath("$[0].title").exists());
-		}
-	}
-
-	@Nested
-	@DisplayName("카테고리 별 카드 갯수 조회 API")
-	class FindCardCountByCategoryTest {
-
-		@Test
-		@WithMockMember
-		@DisplayName("정상 동작시 200 응답 및 응답 포맷 테스트")
-		void shouldReturn200OKAndResponseFormatTest() throws Exception {
-			Mockito.doReturn(1L)
-				.when(cardService).findCardsCountByCategoryId(any(), any());
-			mockMvc.perform(get("/api/v1/cards//categories/{categoryId}/me/count", Id.generateNextId()))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("count").exists());
+				.andExpect(jsonPath("title").exists())
+				.andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse(),
+					requestHeaders(headerWithName("Authorization").description("jwt token")),
+					pathParameters(parameterWithName("cardId").description("카드 아이디")),
+					responseFields(fieldWithPath("cardId").description("카드 아이디"),
+						fieldWithPath("question").description("카드 질문"), fieldWithPath("memberId").description("멤버 아이디"),
+						fieldWithPath("cardType").description("카드 타입"), fieldWithPath("answer").description("카드 정답"),
+						fieldWithPath("description").description("카드 설명"), fieldWithPath("title").description("카드 제목"),
+						fieldWithPath("createdAt").description("카드 생성일"),
+						fieldWithPath("modifiedAt").description("카드 수정일"),
+						fieldWithPath("categoryId").description("카테고리 아이디"))));
 		}
 	}
 
@@ -335,6 +338,7 @@ class CardControllerTest {
 		@Test
 		@DisplayName("정상 동작시 200 응답 및 응답 포맷 테스트")
 		void shouldReturn200OkAndResponseFormatTest() throws Exception {
+			// given
 			OxCard card = OxCard.builder()
 				.cardId(Id.generateNextId())
 				.categoryId(Id.generateNextId())
@@ -343,6 +347,8 @@ class CardControllerTest {
 				.question(new Question("question"))
 				.oxAnswer(OxAnswer.O)
 				.description(new Description("description"))
+				.createdAt(LocalDateTime.now())
+				.modifiedAt(LocalDateTime.now())
 				.build();
 			Member member = Member.builder()
 				.memberId(Id.generateNextId())
@@ -351,10 +357,12 @@ class CardControllerTest {
 				.oAuthType(OAuthType.KAKAO)
 				.oauthId("id")
 				.role(Role.USER)
+				.createdAt(LocalDateTime.now())
+				.modifiedAt(LocalDateTime.now())
 				.build();
-			Mockito.doReturn(new SharedCardResponseDto(card, member))
-				.when(cardService).findSharedCard(any());
+			Mockito.doReturn(new SharedCardResponseDto(card, member)).when(cardService).findSharedCard(any());
 
+			// when
 			mockMvc.perform(get("/api/v1/cards/{cardId}/share", Id.generateNextId()))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.cardInfo.cardId").exists())
@@ -369,7 +377,108 @@ class CardControllerTest {
 				.andExpect(jsonPath("$.memberInfo.email").exists())
 				.andExpect(jsonPath("$.memberInfo.name").exists())
 				.andExpect(jsonPath("$.memberInfo.oauthType").exists())
-				.andExpect(jsonPath("$.memberInfo.role").exists());
+				.andExpect(jsonPath("$.memberInfo.role").exists())
+				.andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse(),
+					pathParameters(parameterWithName("cardId").description("카드 아이디")),
+					responseFields(fieldWithPath("cardInfo.cardId").description("카드 아이디"),
+						fieldWithPath("cardInfo.title").description("카드 제목"),
+						fieldWithPath("cardInfo.memberId").description("카드 멤버 아이디"),
+						fieldWithPath("cardInfo.question").description("카드 질문"),
+						fieldWithPath("cardInfo.categoryId").description("카테고리 아이디"),
+						fieldWithPath("cardInfo.cardType").description("카드 타입"),
+						fieldWithPath("cardInfo.answer").description("카드 정답"),
+						fieldWithPath("cardInfo.description").description("카드 설명"),
+						fieldWithPath("cardInfo.createdAt").description("카드 생성일"),
+						fieldWithPath("cardInfo.modifiedAt").description("카드 수정일"),
+						fieldWithPath("memberInfo.memberId").description("멤버 아이디"),
+						fieldWithPath("memberInfo.name").description("멤버 이름"),
+						fieldWithPath("memberInfo.email").description("멤버 이메일"),
+						fieldWithPath("memberInfo.profile").description("멤버 profile 이미지"),
+						fieldWithPath("memberInfo.role").description("멤버 권한"),
+						fieldWithPath("memberInfo.createdAt").description("멤버 생성일"),
+						fieldWithPath("memberInfo.modifiedAt").description("멤버 수정일"),
+						fieldWithPath("memberInfo.oauthType").description("KAKAO, NAVER, GOOGLE"),
+						fieldWithPath("memberInfo.deleted").description("멤버 삭제 여부"))));
+		}
+	}
+
+	/**
+	 * 성공시 200 응답코드와 리턴해야할 값 검증
+	 */
+	@Nested
+	@DisplayName("개인 카드 커서 페이징 조회 API")
+	class CardCursorPagingSearchTest {
+
+		@Test
+		@WithMockMember
+		void shouldReturn200WhenSuccessTest() throws Exception {
+			// given
+			List<CardResponseDto> contents = List.of(makeResponse());
+			CardCursorPageWithCategory cardCursorPageWithCategory = new CardCursorPageWithCategory(contents,
+				Id.generateNextId(), 5, SortOrder.DESC);
+			cardCursorPageWithCategory.setCategory(Category.builder()
+				.categoryId(Id.generateNextId())
+				.title(new com.almondia.meca.category.domain.vo.Title("title"))
+				.build());
+			Mockito.doReturn(cardCursorPageWithCategory)
+				.when(cardService)
+				.searchCursorPagingCard(anyInt(), any(), any(), any(), any());
+
+			// when
+			ResultActions resultActions = mockMvc.perform(
+				get("/api/v1/cards/categories/{categoryId}/me", Id.generateNextId()).header("Authorization", jwtToken)
+					.queryParam("hasNext", Id.generateNextId().toString())
+					.queryParam("pageSize", "5")
+					.queryParam("containTitle", "title"));
+
+			// then
+			resultActions.andExpect(status().isOk())
+				.andExpect(jsonPath("contents").exists())
+				.andExpect(jsonPath("pageSize").exists())
+				.andExpect(jsonPath("sortOrder").exists())
+				.andExpect(jsonPath("category").exists())
+				.andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse(),
+					requestHeaders(headerWithName("Authorization").description("jwt 토큰")),
+					pathParameters(parameterWithName("categoryId").description("카테고리 아이디")),
+					requestParameters(parameterWithName("hasNext").description("다음 페이지가 있는지 여부").optional(),
+						parameterWithName("pageSize").description("페이지 사이즈"),
+						parameterWithName("containTitle").description("카드 제목 포함 여부").optional()),
+					responseFields(fieldWithPath("contents[].cardId").description("카드 아이디"),
+						fieldWithPath("contents[].title").description("카드 제목"),
+						fieldWithPath("contents[].memberId").description("카드 멤버 아이디"),
+						fieldWithPath("contents[].question").description("카드 질문"),
+						fieldWithPath("contents[].categoryId").description("카테고리 아이디"),
+						fieldWithPath("contents[].cardType").description("카드 타입"),
+						fieldWithPath("contents[].answer").description("카드 정답"),
+						fieldWithPath("contents[].description").description("카드 설명"),
+						fieldWithPath("contents[].createdAt").description("카드 생성일"),
+						fieldWithPath("contents[].modifiedAt").description("카드 수정일"),
+						fieldWithPath("pageSize").description("페이지 사이즈"),
+						fieldWithPath("sortOrder").description("정렬 방식"),
+						fieldWithPath("hasNext").description("다음 페이지가 있는지 여부"),
+						fieldWithPath("category.categoryId").description("카테고리 아이디"),
+						fieldWithPath("category.title").description("카테고리 제목"),
+						fieldWithPath("category.thumbnail").description("카테고리 썸네일"),
+						fieldWithPath("category.shared").description("카테고리 공유 여부"),
+						fieldWithPath("category.createdAt").description("카테고리 생성일"),
+						fieldWithPath("category.modifiedAt").description("카테고리 수정일"),
+						fieldWithPath("category.deleted").description("카테고리 삭제 여부"),
+						fieldWithPath("category.memberId").description("카테고리 멤버 아이디"))));
+		}
+
+		private CardResponseDto makeResponse() {
+			return CardResponseDto.builder()
+				.cardId(Id.generateNextId())
+				.title(new Title("title"))
+				.memberId(Id.generateNextId())
+				.question(new Question("hello"))
+				.categoryId(Id.generateNextId())
+				.cardType(CardType.OX_QUIZ)
+				.answer(OxAnswer.O.name())
+				.description(new Description("hello"))
+				.createdAt(LocalDateTime.now())
+				.modifiedAt(LocalDateTime.now())
+				.build();
 		}
 	}
 
@@ -380,10 +489,10 @@ class CardControllerTest {
 		@Test
 		@DisplayName("정상 동작시 200 응답 및 응답 포맷 테스트")
 		void shouldReturn200OkAndResponseFormatTest() throws Exception {
+			// given
 			List<SharedCardResponseDto> contents = List.of(makeResponse());
 			CardCursorPageWithSharedCategoryDto cardCursorPageWithCategory = new CardCursorPageWithSharedCategoryDto(
-				contents,
-				Id.generateNextId(), 5, SortOrder.DESC);
+				contents, Id.generateNextId(), 5, SortOrder.DESC);
 			cardCursorPageWithCategory.setCategory(Category.builder()
 				.categoryId(Id.generateNextId())
 				.title(new com.almondia.meca.category.domain.vo.Title("title"))
@@ -391,19 +500,143 @@ class CardControllerTest {
 			Mockito.doReturn(cardCursorPageWithCategory)
 				.when(cardService)
 				.searchCursorPagingSharedCard(anyInt(), any(), any(), any());
-			mockMvc.perform(
-					get("/api/v1/cards/categories/{categoryId}/share?pageSize=100&sortOrder=desc", Id.generateNextId()))
-				.andExpect(status().isOk())
+
+			// when
+			ResultActions resultActions = mockMvc.perform(
+				get("/api/v1/cards/categories/{categoryId}/share", Id.generateNextId()).queryParam("hasNext",
+					Id.generateNextId().toString()).queryParam("pageSize", "5").queryParam("containTitle", "title"));
+
+			// then
+			resultActions.andExpect(status().isOk())
 				.andExpect(jsonPath("contents").exists())
 				.andExpect(jsonPath("pageSize").exists())
 				.andExpect(jsonPath("sortOrder").exists())
-				.andExpect(jsonPath("category").exists());
+				.andExpect(jsonPath("category").exists())
+				.andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse(),
+					pathParameters(parameterWithName("categoryId").description("카테고리 아이디")),
+					requestParameters(parameterWithName("hasNext").description("다음 페이지가 있는지 여부").optional(),
+						parameterWithName("pageSize").description("페이지 사이즈"),
+						parameterWithName("containTitle").description("카드 제목 포함 여부").optional()),
+					responseFields(fieldWithPath("contents[].cardInfo.cardId").description("카드 아이디"),
+						fieldWithPath("contents[].cardInfo.title").description("카드 제목"),
+						fieldWithPath("contents[].cardInfo.memberId").description("카드 멤버 아이디"),
+						fieldWithPath("contents[].cardInfo.question").description("카드 질문"),
+						fieldWithPath("contents[].cardInfo.categoryId").description("카테고리 아이디"),
+						fieldWithPath("contents[].cardInfo.cardType").description("카드 타입"),
+						fieldWithPath("contents[].cardInfo.answer").description("카드 정답"),
+						fieldWithPath("contents[].cardInfo.description").description("카드 설명"),
+						fieldWithPath("contents[].cardInfo.createdAt").description("카드 생성일"),
+						fieldWithPath("contents[].cardInfo.modifiedAt").description("카드 수정일"),
+						fieldWithPath("contents[].memberInfo.memberId").description("멤버 아이디"),
+						fieldWithPath("contents[].memberInfo.email").description("멤버 이메일"),
+						fieldWithPath("contents[].memberInfo.name").description("멤버 이름"),
+						fieldWithPath("contents[].memberInfo.profile").description("멤버 프로필 이미지"),
+						fieldWithPath("contents[].memberInfo.role").description("멤버 권한"),
+						fieldWithPath("contents[].memberInfo.createdAt").description("멤버 생성일"),
+						fieldWithPath("contents[].memberInfo.modifiedAt").description("멤버 수정일"),
+						fieldWithPath("contents[].memberInfo.deleted").description("멤버 삭제 여부"),
+						fieldWithPath("contents[].memberInfo.oauthType").description("KAKAO, GOOGLE, NAVER"),
+						fieldWithPath("pageSize").description("페이지 사이즈"),
+						fieldWithPath("sortOrder").description("정렬 방식"),
+						fieldWithPath("hasNext").description("다음 페이지가 있는지 여부"),
+						fieldWithPath("category.categoryId").description("카테고리 아이디"),
+						fieldWithPath("category.title").description("카테고리 제목"),
+						fieldWithPath("category.thumbnail").description("카테고리 썸네일"),
+						fieldWithPath("category.shared").description("카테고리 공유 여부"),
+						fieldWithPath("category.createdAt").description("카테고리 생성일"),
+						fieldWithPath("category.modifiedAt").description("카테고리 수정일"),
+						fieldWithPath("category.deleted").description("카테고리 삭제 여부"),
+						fieldWithPath("category.memberId").description("카테고리 멤버 아이디"))));
 		}
 
 		private SharedCardResponseDto makeResponse() {
 			Card card = CardTestHelper.genOxCard(Id.generateNextId(), Id.generateNextId(), Id.generateNextId());
 			Member member = MemberTestHelper.generateMember(Id.generateNextId());
 			return new SharedCardResponseDto(card, member);
+		}
+	}
+
+	/**
+	 *  정상 동작시 200 응답 및 응답 포맷 테스트
+	 */
+	@Nested
+	@DisplayName("카드 시뮬레이션 테스트")
+	class SimulateCardTest {
+
+		@Test
+		@WithMockMember
+		@DisplayName("정상 동작시 200 응답 및 응답 포맷 테스트")
+		void shouldReturn200WhenSuccessTest() throws Exception {
+			// given
+			CardResponseDto responseDto = CardResponseDto.builder()
+				.cardId(Id.generateNextId())
+				.memberId(Id.generateNextId())
+				.categoryId(Id.generateNextId())
+				.question(new Question("question"))
+				.cardType(CardType.OX_QUIZ)
+				.answer("O")
+				.description(new Description("hello"))
+				.title(new Title("title1"))
+				.createdAt(LocalDateTime.now())
+				.modifiedAt(LocalDateTime.now())
+				.build();
+			Mockito.doReturn(List.of(responseDto)).when(cardSimulationService).simulateRandom(any(), any(), anyInt());
+
+			// when
+			ResultActions resultActions = mockMvc.perform(
+				get("/api/v1/cards/categories/{categoryId}/simulation", Id.generateNextId()).header("Authorization",
+					jwtToken).queryParam("limit", "3").queryParam("algorithm", "random"));
+
+			// then
+			resultActions.andExpect(status().isOk())
+				.andExpect(jsonPath("$[0].cardId").exists())
+				.andExpect(jsonPath("$[0].memberId").exists())
+				.andExpect(jsonPath("$[0].question").exists())
+				.andExpect(jsonPath("$[0].cardType").exists())
+				.andExpect(jsonPath("$[0].answer").exists())
+				.andExpect(jsonPath("$[0].description").exists())
+				.andExpect(jsonPath("$[0].title").exists())
+				.andDo(document("{class-name}/{method-name}",
+					requestHeaders(headerWithName("Authorization").description("JWT 인증 토큰")),
+					pathParameters(parameterWithName("categoryId").description("카테고리 아이디")),
+					requestParameters(parameterWithName("limit").description("카드 갯수"),
+						parameterWithName("algorithm").description("카드 알고리즘(random, score")),
+					responseFields(fieldWithPath("[].cardId").description("카드 아이디"),
+						fieldWithPath("[].memberId").description("멤버 아이디"),
+						fieldWithPath("[].categoryId").description("카테고리 아이디"),
+						fieldWithPath("[].question").description("카드 질문"),
+						fieldWithPath("[].cardType").description("카드 타입"),
+						fieldWithPath("[].answer").description("카드 정답"),
+						fieldWithPath("[].description").description("카드 설명"),
+						fieldWithPath("[].title").description("카드 제목"),
+						fieldWithPath("[].createdAt").description("카드 생성일"),
+						fieldWithPath("[].modifiedAt").description("카드 수정일"))));
+		}
+	}
+
+	@Nested
+	@DisplayName("카테고리 별 카드 갯수 조회 API")
+	class FindCardCountByCategoryTest {
+
+		@Test
+		@WithMockMember
+		@DisplayName("정상 동작시 200 응답 및 응답 포맷 테스트")
+		void shouldReturn200OKAndResponseFormatTest() throws Exception {
+			// given
+			Mockito.doReturn(1L).when(cardService).findCardsCountByCategoryId(any(), any());
+
+			// when
+			ResultActions resultActions = mockMvc.perform(
+				get("/api/v1/cards//categories/{categoryId}/me/count", Id.generateNextId())
+					.header("Authorization", jwtToken));
+
+			// then
+			resultActions.andExpect(status().isOk())
+				.andExpect(jsonPath("count").exists())
+				.andDo(document("{class-name}/{method-name}",
+					requestHeaders(headerWithName("Authorization").description("JWT 인증 토큰")),
+					pathParameters(parameterWithName("categoryId").description("카테고리 아이디")),
+					responseFields(fieldWithPath("count").description("카드 갯수"))));
 		}
 	}
 }

--- a/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/almondia/meca/category/controller/CategoryControllerTest.java
@@ -1,7 +1,13 @@
 package com.almondia.meca.category.controller;
 
+import static com.almondia.meca.asciidocs.ApiDocumentUtils.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.snippet.Attributes.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -9,23 +15,27 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 import com.almondia.meca.category.application.CategoryService;
-import com.almondia.meca.category.controller.dto.CategoryResponseDto;
 import com.almondia.meca.category.controller.dto.CategoryWithHistoryResponseDto;
-import com.almondia.meca.category.controller.dto.SaveCategoryRequestDto;
 import com.almondia.meca.category.controller.dto.SharedCategoryResponseDto;
 import com.almondia.meca.category.controller.dto.UpdateCategoryRequestDto;
 import com.almondia.meca.category.domain.vo.Title;
@@ -43,11 +53,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(CategoryController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith({RestDocumentationExtension.class})
 @Import({WebMvcConfiguration.class, JacksonConfiguration.class})
 class CategoryControllerTest {
 
+	private static final String jwtToken = "jwt token";
+
 	@Autowired
+	WebApplicationContext context;
+
 	MockMvc mockMvc;
 
 	@MockBean
@@ -59,6 +73,14 @@ class CategoryControllerTest {
 	@Autowired
 	ObjectMapper objectMapper;
 
+	@BeforeEach
+	public void setUp(RestDocumentationContextProvider restDocumentation) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.alwaysDo(print())
+			.apply(documentationConfiguration(restDocumentation))
+			.build();
+	}
+
 	/**
 	 * 1. 카테고리 등록시 성공하면 201 코드 및 응답 검증
 	 */
@@ -68,22 +90,21 @@ class CategoryControllerTest {
 		@Test
 		@DisplayName("카테고리 등록시 성공하면 201 코드 및 응답 검증")
 		@WithMockMember
-		void test() throws Exception {
-			Mockito.doReturn(CategoryResponseDto
-				.builder()
-				.categoryId(Id.generateNextId())
-				.memberId(Id.generateNextId())
-				.thumbnail(new Image("https://aws.s3.com"))
-				.title(Title.of("title"))
-				.isDeleted(false)
-				.createdAt(LocalDateTime.now())
-				.modifiedAt(LocalDateTime.now())
-				.build()).when(categoryservice).saveCategory(any(), any());
-			mockMvc.perform(post("/api/v1/categories")
-					.contentType(MediaType.APPLICATION_JSON)
-					.characterEncoding(StandardCharsets.UTF_8)
-					.content(makeCategoryRequestDto()))
-				.andExpect(status().isCreated())
+		void shouldReturn201WhenEnrollSuccessTest() throws Exception {
+			// given
+			Mockito.doReturn(CategoryTestHelper.generateCategoryResponseDto())
+				.when(categoryservice)
+				.saveCategory(any(), any());
+			String saveRequest = objectMapper.writeValueAsString(CategoryTestHelper.generateSaveCategoryRequestDto());
+
+			// when
+			ResultActions result = mockMvc.perform(post("/api/v1/categories").header("Authorization", jwtToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding(StandardCharsets.UTF_8)
+				.content(saveRequest));
+
+			//then
+			result.andExpect(status().isCreated())
 				.andExpect(jsonPath("categoryId").exists())
 				.andExpect(jsonPath("memberId").exists())
 				.andExpect(jsonPath("title").exists())
@@ -91,13 +112,20 @@ class CategoryControllerTest {
 				.andExpect(jsonPath("deleted").exists())
 				.andExpect(jsonPath("shared").exists())
 				.andExpect(jsonPath("createdAt").exists())
-				.andExpect(jsonPath("modifiedAt").exists());
-		}
-
-		private String makeCategoryRequestDto() throws JsonProcessingException {
-			SaveCategoryRequestDto requestDto = SaveCategoryRequestDto.builder().title(Title.of("title"))
-				.thumbnail(new Image("https://aws.s3.com")).build();
-			return objectMapper.writeValueAsString(requestDto);
+				.andExpect(jsonPath("modifiedAt").exists())
+				.andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse(),
+					requestHeaders(headerWithName("Authorization").description("JWT Bearer 토큰")), requestFields(
+						fieldWithPath("title").description("카테고리 제목").attributes(key("constraints").value("최대 40자")),
+						fieldWithPath("thumbnail").description("카테고리 썸네일 이미지 링크(s3)")
+							.optional()
+							.attributes(key("constraints").value("최대 255자"))),
+					responseFields(fieldWithPath("categoryId").description("카테고리 아이디"),
+						fieldWithPath("memberId").description("회원 아이디"), fieldWithPath("title").description("카테고리 제목"),
+						fieldWithPath("thumbnail").description("카테고리 썸네일 이미지"),
+						fieldWithPath("deleted").description("카테고리 삭제 여부"),
+						fieldWithPath("shared").description("카테고리 공유 여부"),
+						fieldWithPath("createdAt").description("카테고리 생성일"),
+						fieldWithPath("modifiedAt").description("카테고리 수정일"))));
 		}
 	}
 
@@ -113,26 +141,46 @@ class CategoryControllerTest {
 		@WithMockMember
 		@DisplayName("카테 고리 수정 응답 코드 200 및 정상 응답 테스트")
 		void shouldReturn200WhenSuccessUpdateCategoryTest() throws Exception {
-			Mockito.doReturn(CategoryResponseDto.builder()
-					.categoryId(Id.generateNextId())
-					.memberId(Id.generateNextId())
-					.title(new Title("title"))
-					.createdAt(LocalDateTime.now())
-					.modifiedAt(LocalDateTime.now())
-					.build())
-				.when(categoryservice).updateCategory(any(), any(), any());
-			mockMvc.perform(put("/api/v1/categories/{categoryId}", Id.generateNextId())
-					.contentType(MediaType.APPLICATION_JSON)
+			// given
+			Mockito.doReturn(CategoryTestHelper.generateCategoryResponseDto())
+				.when(categoryservice)
+				.updateCategory(any(), any(), any());
+
+			// when
+			ResultActions result = mockMvc.perform(
+				put("/api/v1/categories/{categoryId}", Id.generateNextId()).contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8)
-					.content(makeCategoryRequestDto()))
-				.andExpect(status().isOk())
+					.header("Authorization", jwtToken)
+					.content(makeCategoryRequestDto()));
+
+			// then
+			result.andExpect(status().isOk())
 				.andExpect(jsonPath("categoryId").exists())
 				.andExpect(jsonPath("memberId").exists())
 				.andExpect(jsonPath("title").exists())
 				.andExpect(jsonPath("deleted").exists())
 				.andExpect(jsonPath("shared").exists())
 				.andExpect(jsonPath("createdAt").exists())
-				.andExpect(jsonPath("modifiedAt").exists());
+				.andExpect(jsonPath("modifiedAt").exists())
+				.andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse(),
+					requestHeaders(headerWithName("Authorization").description("JWT Bearer 토큰")),
+					pathParameters(parameterWithName("categoryId").description("카테고리 아이디")), requestFields(
+						fieldWithPath("title").description("카테고리 제목")
+							.optional()
+							.attributes(key("constraints").value("최대 40자")),
+						fieldWithPath("thumbnail").description("카테고리 썸네일 이미지 링크(s3)")
+							.optional()
+							.attributes(key("constraints").value("최대 255자")),
+						fieldWithPath("isShared").description("카테고리 공유 여부")
+							.optional()
+							.attributes(key("constraints").value("true or false"))),
+					responseFields(fieldWithPath("categoryId").description("카테고리 아이디"),
+						fieldWithPath("memberId").description("회원 아이디"), fieldWithPath("title").description("카테고리 제목"),
+						fieldWithPath("thumbnail").description("카테고리 썸네일 이미지"),
+						fieldWithPath("deleted").description("카테고리 삭제 여부"),
+						fieldWithPath("shared").description("카테고리 공유 여부"),
+						fieldWithPath("createdAt").description("카테고리 생성일"),
+						fieldWithPath("modifiedAt").description("카테고리 수정일"))));
 		}
 
 		@Test
@@ -140,17 +188,19 @@ class CategoryControllerTest {
 		@DisplayName("권한 오류가 발생시 403 응답 반환")
 		void shouldThrowWhenAuthorizationErrorTest() throws Exception {
 			Mockito.doThrow(new AccessDeniedException("권한 없음"))
-				.when(categoryservice).updateCategory(any(), any(), any());
-			mockMvc.perform(put("/api/v1/categories/{categoryId}", Id.generateNextId())
-					.contentType(MediaType.APPLICATION_JSON)
+				.when(categoryservice)
+				.updateCategory(any(), any(), any());
+			mockMvc.perform(
+				put("/api/v1/categories/{categoryId}", Id.generateNextId()).contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding(StandardCharsets.UTF_8)
-					.content(makeCategoryRequestDto()))
-				.andExpect(status().isForbidden());
+					.content(makeCategoryRequestDto())).andExpect(status().isForbidden());
 		}
 
 		private String makeCategoryRequestDto() throws JsonProcessingException {
 			UpdateCategoryRequestDto updateCategoryRequestDto = UpdateCategoryRequestDto.builder()
 				.title(new Title("title"))
+				.thumbnail(new Image("https://aws.s3.com"))
+				.isShared(true)
 				.build();
 			return objectMapper.writeValueAsString(updateCategoryRequestDto);
 		}
@@ -164,6 +214,7 @@ class CategoryControllerTest {
 		@DisplayName("카테 고리 페이징 조회 응답 코드 200 및 정상 응답 테스트")
 		@WithMockMember
 		void shouldReturnPageTypeWhenCallPagingSearchTest() throws Exception {
+			// given
 			CategoryWithHistoryResponseDto content = CategoryWithHistoryResponseDto.builder()
 				.categoryId(Id.generateNextId())
 				.memberId(Id.generateNextId())
@@ -177,19 +228,55 @@ class CategoryControllerTest {
 				.build();
 			CursorPage<CategoryWithHistoryResponseDto> response = CursorPage.<CategoryWithHistoryResponseDto>builder()
 				.contents(List.of(content))
-				.pageSize(1).hasNext(Id.generateNextId())
+				.pageSize(1)
+				.hasNext(Id.generateNextId())
 				.sortOrder(SortOrder.DESC)
 				.build();
 			Mockito.doReturn(response)
-				.when(categoryservice).findCursorPagingCategoryWithHistoryResponse(anyInt(), any(), any(), any());
+				.when(categoryservice)
+				.findCursorPagingCategoryWithHistoryResponse(anyInt(), any(), any(), any());
 
-			final String url = "/api/v1/categories/me?pageSize=4&sortField=createdAt&startCreatedAt=2023-03-13T10:23";
-			mockMvc.perform(get(url))
-				.andExpect(status().isOk())
+			// when
+			ResultActions resultActions = mockMvc.perform(get("/api/v1/categories/me")
+				.header("Authorization", "Bearer " + jwtToken)
+				.queryParam("pageSize", "4")
+				.queryParam("hasNext", Id.generateNextId().toString())
+				.queryParam("containTitle", "title"));
+
+			// then
+			resultActions.andExpect(status().isOk())
 				.andExpect(jsonPath("pageSize").exists())
 				.andExpect(jsonPath("hasNext").exists())
 				.andExpect(jsonPath("sortOrder").exists())
-				.andDo(print());
+				.andDo(document(
+					"{class-name}/{method-name}",
+					getDocumentRequest(),
+					getDocumentResponse(),
+					requestHeaders(
+						headerWithName("Authorization").description("JWT Bearer 토큰")
+					),
+					requestParameters(
+						parameterWithName("pageSize").description("페이지 사이즈"),
+						parameterWithName("hasNext").description("다음 페이지 커서").optional(),
+						parameterWithName("containTitle").description("카테고리 제목 포함 여부(null인 경우 전체 검색)").optional()
+					),
+					responseFields(
+						fieldWithPath("pageSize").description("페이지 사이즈"),
+						fieldWithPath("hasNext").description("다음 페이지 커서"),
+						fieldWithPath("sortOrder").description("정렬 방식"),
+						fieldWithPath("contents[].categoryId").description("카테고리 아이디"),
+						fieldWithPath("contents[].memberId").description("회원 아이디"),
+						fieldWithPath("contents[].title").description("카테고리 제목"),
+						fieldWithPath("contents[].thumbnail").description("카테고리 썸네일 이미지"),
+						fieldWithPath("contents[].createdAt").description("카테고리 생성일"),
+						fieldWithPath("contents[].modifiedAt").description("카테고리 수정일"),
+						fieldWithPath("contents[].scoreAvg").description("카테고리 평균 점수"),
+						fieldWithPath("contents[].solveCount").description("카테고리 문제 풀이 수"),
+						fieldWithPath("contents[].totalCount").description("카테고리 문제 수"),
+						fieldWithPath("contents[].deleted").description("카테고리 삭제 여부"),
+						fieldWithPath("contents[].shared").description("카테고리 공유 여부")
+					)
+				));
 		}
 	}
 
@@ -201,8 +288,25 @@ class CategoryControllerTest {
 		@WithMockMember
 		@DisplayName("카테고리 삭제 성공시 응답 200")
 		void shouldReturnStatus200WhenSuccessTest() throws Exception {
-			mockMvc.perform(delete("/api/v1/categories/{categoryId}", Id.generateNextId()))
-				.andExpect(status().isOk());
+			// given
+			Id categoryId = Id.generateNextId();
+
+			// when
+			ResultActions resultActions = mockMvc.perform(delete("/api/v1/categories/{categoryId}", categoryId)
+				.header("Authorization", "Bearer " + jwtToken));
+
+			resultActions.andExpect(status().isOk())
+				.andDo(document(
+					"{class-name}/{method-name}",
+					getDocumentRequest(),
+					getDocumentResponse(),
+					requestHeaders(
+						headerWithName("Authorization").description("JWT Bearer 토큰")
+					),
+					pathParameters(
+						parameterWithName("categoryId").description("카테고리 아이디")
+					)
+				));
 		}
 	}
 
@@ -213,6 +317,7 @@ class CategoryControllerTest {
 		@Test
 		@DisplayName("카테고리 공유 커서 페이징 성공시 응답 200 및 정상 응답")
 		void shouldReturnStatus200AndResponseWhenSuccessTest() throws Exception {
+			// given
 			CursorPage<SharedCategoryResponseDto> cursorPage = CursorPage.<SharedCategoryResponseDto>builder()
 				.pageSize(2)
 				.contents(List.of(new SharedCategoryResponseDto(
@@ -224,13 +329,51 @@ class CategoryControllerTest {
 			Mockito.doReturn(cursorPage)
 				.when(categoryservice)
 				.findCursorPagingCategoryResponseDto(anyInt(), any(), any());
-			mockMvc.perform(get("/api/v1/categories/share?pageSize=2"))
-				.andExpect(status().isOk())
+
+			// when
+			ResultActions resultActions = mockMvc.perform(get("/api/v1/categories/share")
+				.queryParam("hasNext", Id.generateNextId().toString())
+				.queryParam("containTitle", "title")
+				.queryParam("pageSize", "2"));
+
+			// then
+			resultActions.andExpect(status().isOk())
 				.andExpect(jsonPath("pageSize").exists())
 				.andExpect(jsonPath("hasNext").exists())
 				.andExpect(jsonPath("sortOrder").exists())
 				.andExpect(jsonPath("contents").exists())
-				.andDo(print());
+				.andDo(document(
+					"{class-name}/{method-name}",
+					getDocumentRequest(),
+					getDocumentResponse(),
+					requestParameters(
+						parameterWithName("hasNext").description("다음 페이지 커서").optional(),
+						parameterWithName("containTitle").description("카테고리 제목 포함 여부(null인 경우 전체 검색)").optional(),
+						parameterWithName("pageSize").description("페이지 사이즈")
+					),
+					responseFields(
+						fieldWithPath("pageSize").description("페이지 사이즈"),
+						fieldWithPath("hasNext").description("다음 페이지 커서"),
+						fieldWithPath("sortOrder").description("정렬 방식"),
+						fieldWithPath("contents[].categoryInfo.categoryId").description("카테고리 아이디"),
+						fieldWithPath("contents[].categoryInfo.memberId").description("회원 아이디"),
+						fieldWithPath("contents[].categoryInfo.title").description("카테고리 제목"),
+						fieldWithPath("contents[].categoryInfo.thumbnail").description("카테고리 썸네일 이미지"),
+						fieldWithPath("contents[].categoryInfo.createdAt").description("카테고리 생성일"),
+						fieldWithPath("contents[].categoryInfo.modifiedAt").description("카테고리 수정일"),
+						fieldWithPath("contents[].categoryInfo.deleted").description("카테고리 삭제 여부"),
+						fieldWithPath("contents[].categoryInfo.shared").description("카테고리 공유 여부"),
+						fieldWithPath("contents[].memberInfo.memberId").description("회원 아이디"),
+						fieldWithPath("contents[].memberInfo.name").description("회원 이름"),
+						fieldWithPath("contents[].memberInfo.email").description("회원 email"),
+						fieldWithPath("contents[].memberInfo.profile").description("회원 프로필 이미지"),
+						fieldWithPath("contents[].memberInfo.role").description("회원 역할"),
+						fieldWithPath("contents[].memberInfo.createdAt").description("회원 생성일"),
+						fieldWithPath("contents[].memberInfo.modifiedAt").description("회원 수정일"),
+						fieldWithPath("contents[].memberInfo.oauthType").description("Oauth 타입"),
+						fieldWithPath("contents[].memberInfo.deleted").description("회원 삭제 여부")
+					)
+				));
 		}
 	}
 }

--- a/src/test/java/com/almondia/meca/category/domain/entity/CategoryTest.java
+++ b/src/test/java/com/almondia/meca/category/domain/entity/CategoryTest.java
@@ -2,8 +2,6 @@ package com.almondia.meca.category.domain.entity;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.time.LocalDateTime;
-
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.metamodel.EntityType;
@@ -13,8 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 
 import com.almondia.meca.category.domain.vo.Title;
 import com.almondia.meca.common.configuration.jpa.JpaAuditingConfiguration;
@@ -50,41 +46,6 @@ class CategoryTest {
 			.containsExactlyInAnyOrder("memberId", "categoryId", "title", "thumbnail", "isDeleted", "isShared",
 				"createdAt",
 				"modifiedAt");
-	}
-
-	@Test
-	@DisplayName("엔티티 생성시 생성일과 수정일이 동일하게 생성되는지 검증")
-	void shouldUpdateCreatedAtAndEqualModifiedAtWhenEntitySave() {
-		JpaRepository<Category, Id> categoryRepository = new SimpleJpaRepository<>(Category.class, entityManager);
-		Category category = Category.builder()
-			.categoryId(Id.generateNextId())
-			.memberId(Id.generateNextId())
-			.title(new Title("title"))
-			.build();
-		categoryRepository.saveAndFlush(category);
-		Category result = categoryRepository.findById(category.getCategoryId()).orElseThrow();
-		LocalDateTime createdAt = result.getCreatedAt();
-		LocalDateTime modifiedAt = result.getModifiedAt();
-		assertThat(createdAt).isEqualTo(modifiedAt);
-	}
-
-	@Test
-	@DisplayName("엔티티 수정시 수정일이 수정되고 생성일보다 이후 날짜가 되야 한다")
-	void shouldUpdateModifiedAtAndAfterThanCreatedAtWhenEntityModifiedTest() throws InterruptedException {
-		JpaRepository<Category, Id> categoryRepository = new SimpleJpaRepository<>(Category.class, entityManager);
-		Category category = Category.builder()
-			.categoryId(Id.generateNextId())
-			.memberId(Id.generateNextId())
-			.title(new Title("title"))
-			.build();
-		Category temp = categoryRepository.save(category);
-		temp.delete();
-		categoryRepository.saveAndFlush(temp);
-		Thread.sleep(100);
-		Category result = categoryRepository.findById(category.getCategoryId()).orElseThrow();
-		LocalDateTime createdAt = result.getCreatedAt();
-		LocalDateTime modifiedAt = result.getModifiedAt();
-		assertThat(modifiedAt).isAfter(createdAt);
 	}
 
 	@Test

--- a/src/test/java/com/almondia/meca/helper/CategoryTestHelper.java
+++ b/src/test/java/com/almondia/meca/helper/CategoryTestHelper.java
@@ -2,9 +2,12 @@ package com.almondia.meca.helper;
 
 import java.time.LocalDateTime;
 
+import com.almondia.meca.category.controller.dto.CategoryResponseDto;
+import com.almondia.meca.category.controller.dto.SaveCategoryRequestDto;
 import com.almondia.meca.category.domain.entity.Category;
 import com.almondia.meca.category.domain.vo.Title;
 import com.almondia.meca.common.domain.vo.Id;
+import com.almondia.meca.common.domain.vo.Image;
 
 public class CategoryTestHelper {
 
@@ -27,6 +30,26 @@ public class CategoryTestHelper {
 			.title(Title.of(title))
 			.isDeleted(false)
 			.isShared(true)
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.build();
+	}
+
+	public static SaveCategoryRequestDto generateSaveCategoryRequestDto() {
+		return SaveCategoryRequestDto.builder()
+			.title(Title.of("title"))
+			.thumbnail(new Image("https://aws.s3.com"))
+			.build();
+	}
+
+	public static CategoryResponseDto generateCategoryResponseDto() {
+		return CategoryResponseDto.builder()
+			.categoryId(Id.generateNextId())
+			.memberId(Id.generateNextId())
+			.thumbnail(new Image("https://aws.s3.com"))
+			.title(Title.of("title"))
+			.isDeleted(false)
+			.isShared(false)
 			.createdAt(LocalDateTime.now())
 			.modifiedAt(LocalDateTime.now())
 			.build();

--- a/src/test/java/com/almondia/meca/helper/MemberTestHelper.java
+++ b/src/test/java/com/almondia/meca/helper/MemberTestHelper.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.almondia.meca.common.domain.vo.Id;
 import com.almondia.meca.common.domain.vo.Image;
+import com.almondia.meca.member.controller.dto.MemberResponseDto;
 import com.almondia.meca.member.domain.entity.Member;
 import com.almondia.meca.member.domain.vo.Email;
 import com.almondia.meca.member.domain.vo.Name;
@@ -21,6 +22,34 @@ public class MemberTestHelper {
 			.oauthId("12312`1`1123")
 			.oAuthType(OAuthType.GOOGLE)
 			.role(Role.USER)
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.build();
+	}
+
+	public static MemberResponseDto genMemberResponseDto() {
+		return MemberResponseDto.builder()
+			.memberId(Id.generateNextId())
+			.name(new Name("name"))
+			.email(new Email("email@naver.com"))
+			.profile(new Image("profile"))
+			.oAuthType(OAuthType.KAKAO)
+			.role(Role.USER)
+			.isDeleted(false)
+			.createdAt(LocalDateTime.now())
+			.modifiedAt(LocalDateTime.now())
+			.build();
+	}
+
+	public static MemberResponseDto generateMemberResponseDto(Id memberId) {
+		return MemberResponseDto.builder()
+			.memberId(memberId)
+			.name(new Name("name"))
+			.email(new Email("email@naver.com"))
+			.profile(new Image("profile"))
+			.oAuthType(OAuthType.KAKAO)
+			.role(Role.USER)
+			.isDeleted(false)
 			.createdAt(LocalDateTime.now())
 			.modifiedAt(LocalDateTime.now())
 			.build();

--- a/src/test/java/com/almondia/meca/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/almondia/meca/member/controller/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.almondia.meca.member.controller;
 
 import static com.almondia.meca.asciidocs.ApiDocumentUtils.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -95,6 +96,9 @@ class MemberControllerTest {
 				.andDo(document("{class-name}/{method-name}",
 					getDocumentRequest(),
 					getDocumentResponse(),
+					requestHeaders(
+						headerWithName("Authorization").description("Bearer Token")
+					),
 					responseFields(
 						fieldWithPath("memberId").description("회원 아이디"),
 						fieldWithPath("name").description("회원 이름"),

--- a/src/test/java/com/almondia/meca/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/almondia/meca/member/controller/MemberControllerTest.java
@@ -1,77 +1,89 @@
 package com.almondia.meca.member.controller;
 
+import static com.almondia.meca.asciidocs.ApiDocumentUtils.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.time.LocalDateTime;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 import com.almondia.meca.common.configuration.jackson.JacksonConfiguration;
 import com.almondia.meca.common.configuration.security.filter.JwtAuthenticationFilter;
-import com.almondia.meca.common.domain.vo.Id;
-import com.almondia.meca.common.domain.vo.Image;
+import com.almondia.meca.helper.MemberTestHelper;
 import com.almondia.meca.member.application.MemberService;
-import com.almondia.meca.member.controller.dto.MemberResponseDto;
-import com.almondia.meca.member.domain.vo.Email;
-import com.almondia.meca.member.domain.vo.Name;
-import com.almondia.meca.member.domain.vo.OAuthType;
-import com.almondia.meca.member.domain.vo.Role;
 import com.almondia.meca.mock.security.WithMockMember;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(MemberController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith({RestDocumentationExtension.class})
 @Import({JacksonConfiguration.class})
 class MemberControllerTest {
 
-	@Autowired
-	MockMvc mockMvc;
-
-	@MockBean
-	MemberService memberService;
-
-	@MockBean
-	JwtAuthenticationFilter jwtAuthenticationFilter;
+	private static final String jwtToken = "jwt token";
 
 	@Autowired
-	ObjectMapper objectMapper;
+	private WebApplicationContext context;
+
+	private MockMvc mockMvc;
+
+	@MockBean
+	private MemberService memberService;
+
+	@MockBean
+	private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	public void setUp(RestDocumentationContextProvider restDocumentation) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.alwaysDo(print())
+			.apply(documentationConfiguration(restDocumentation))
+			.build();
+	}
 
 	/**
-	 * 1. 개인 프로필 조회 응답 성공시 리턴값 검증
+	 * 응답 성공시 리턴값 검증
 	 */
 	@Nested
 	@DisplayName("개인 프로필 조회")
-	class getMyProfile {
+	class FindMyProfile {
 
 		@Test
-		@DisplayName("개인 프로필 조회 응답 성공시 리턴값 검증")
+		@DisplayName("응답 성공시 리턴값 검증")
 		@WithMockMember
 		void shouldReturnMemberResponseDtoAttributesWhenReturn200Test() throws Exception {
-			Mockito.doReturn(MemberResponseDto.builder()
-				.memberId(Id.generateNextId())
-				.name(new Name("name"))
-				.email(new Email("email@naver.com"))
-				.profile(new Image("profile"))
-				.oAuthType(OAuthType.KAKAO)
-				.role(Role.USER)
-				.isDeleted(false)
-				.createdAt(LocalDateTime.now())
-				.modifiedAt(LocalDateTime.now())
-				.build()).when(memberService).findMyProfile(any());
+			//given
+			Mockito.doReturn(MemberTestHelper.genMemberResponseDto())
+				.when(memberService)
+				.findMyProfile(any());
 
-			mockMvc.perform(get("/api/v1/members/me"))
-				.andExpect(status().isOk())
+			// when
+			ResultActions result = mockMvc.perform(get("/api/v1/members/me")
+				.header("Authorization", "Bearer " + jwtToken));
+
+			// then
+			result.andExpect(status().isOk())
 				.andExpect(jsonPath("memberId").exists())
 				.andExpect(jsonPath("name").exists())
 				.andExpect(jsonPath("email").exists())
@@ -80,7 +92,23 @@ class MemberControllerTest {
 				.andExpect(jsonPath("role").exists())
 				.andExpect(jsonPath("deleted").exists())
 				.andExpect(jsonPath("createdAt").exists())
-				.andExpect(jsonPath("modifiedAt").exists());
+				.andExpect(jsonPath("modifiedAt").exists())
+				.andDo(document("{class-name}/{method-name}",
+					getDocumentRequest(),
+					getDocumentResponse(),
+					requestHeaders(headerWithName("Authorization").description("JWT Bearer 토큰")),
+					responseFields(
+						fieldWithPath("memberId").description("회원 아이디"),
+						fieldWithPath("name").description("회원 이름"),
+						fieldWithPath("email").description("회원 이메일"),
+						fieldWithPath("profile").description("회원 프로필 사진"),
+						fieldWithPath("oauthType").description("회원 소셜 로그인 타입"),
+						fieldWithPath("role").description("회원 권한"),
+						fieldWithPath("deleted").description("회원 삭제 여부"),
+						fieldWithPath("createdAt").description("회원 생성일"),
+						fieldWithPath("modifiedAt").description("회원 수정일")
+					)
+				));
 		}
 	}
 

--- a/src/test/java/com/almondia/meca/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/almondia/meca/member/controller/MemberControllerTest.java
@@ -2,7 +2,6 @@ package com.almondia.meca.member.controller;
 
 import static com.almondia.meca.asciidocs.ApiDocumentUtils.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -96,7 +95,6 @@ class MemberControllerTest {
 				.andDo(document("{class-name}/{method-name}",
 					getDocumentRequest(),
 					getDocumentResponse(),
-					requestHeaders(headerWithName("Authorization").description("JWT Bearer 토큰")),
 					responseFields(
 						fieldWithPath("memberId").description("회원 아이디"),
 						fieldWithPath("name").description("회원 이름"),

--- a/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
@@ -1,0 +1,9 @@
+.+{{path}}+
+|===
+|파라미터|설명
+
+{{#parameters}}
+	|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,10 @@
+|===
+	|필드명|타입|필수여부|제약조건|설명
+{{#fields}}
+	|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+	|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+	|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+	|{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
+	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+	|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,5 +1,6 @@
 |===
-	|필드명|타입|필수여부|제약조건|설명
+|필드명|타입|필수여부|제약조건|설명
+
 {{#fields}}
 	|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 	|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
@@ -7,4 +8,4 @@
 	|{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
 	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
 {{/fields}}
-	|===
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
@@ -1,8 +1,9 @@
 |===
-	|파라미터|필수여부|설명
+|파라미터|필수여부|설명
+
 {{#parameters}}
 	|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
 	|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
 	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
 {{/parameters}}
-	|===
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
@@ -1,0 +1,8 @@
+|===
+	|파라미터|필수여부|설명
+{{#parameters}}
+	|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+	|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/parameters}}
+	|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,10 +1,9 @@
 |===
-|필드명|타입|필수여부|설명
+|필드명|타입|설명
 
 {{#fields}}
 	|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 	|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
-	|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
 	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
 {{/fields}}
 |===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,9 @@
+|===
+	|필드명|타입|필수여부|설명
+{{#fields}}
+	|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+	|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+	|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+	|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,9 +1,10 @@
 |===
-	|필드명|타입|필수여부|설명
+|필드명|타입|필수여부|설명
+
 {{#fields}}
 	|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 	|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
 	|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
 	|{{#tableCellContent}}{{description}}{{/tableCellContent}}
 {{/fields}}
-	|===
+|===


### PR DESCRIPTION
## 요약

- 컨트롤러 테스트 코드에 rest docs 적용
- build.gradle task 및 의존성 관리를 위해 asciidocs.gradle과 default-dependencies.gradle로 분리해서 build.gradle에 apply
- api 문서 생성 자동화