### PR TITLE
refactor/#152: 카드 갯수 요청 api 권한 수정

### DIFF
--- a/src/main/java/com/almondia/meca/card/application/CardService.java
+++ b/src/main/java/com/almondia/meca/card/application/CardService.java
@@ -92,7 +92,11 @@ public class CardService {
 
 	@Transactional(readOnly = true)
 	public long findCardsCountByCategoryId(Id categoryId, Id memberId) {
-		categoryChecker.checkAuthority(categoryId, memberId);
+		Category category = categoryRepository.findByCategoryIdAndIsDeletedFalse(categoryId)
+			.orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다"));
+		if (!category.isMyCategory(memberId) && !category.isShared()) {
+			throw new AccessDeniedException("공유되지 않은 카테고리에 접근할 수 없습니다");
+		}
 		return cardRepository.countCardsByCategoryId(categoryId);
 	}
 

--- a/src/main/java/com/almondia/meca/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/almondia/meca/category/domain/repository/CategoryRepository.java
@@ -13,4 +13,5 @@ public interface CategoryRepository extends JpaRepository<Category, Id>, Categor
 
 	Optional<Category> findByCategoryIdAndIsDeleted(Id categoryId, boolean isDeleted);
 
+	Optional<Category> findByCategoryIdAndIsDeletedFalse(Id categoryId);
 }


### PR DESCRIPTION
## 요약

- 개인 카테고리의 카드 갯수 요청은 정상 응답
- 외부 카테고리인 경우 공유 상태인 카테고리의 카드만 카드 갯수를 조회할 수 있음