### PR TITLE
fix: CardSnapShot vo attribute 관련 수정

### DIFF
--- a/src/main/java/com/almondia/meca/cardhistory/domain/vo/CardSnapShot.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/vo/CardSnapShot.java
@@ -15,7 +15,6 @@ import com.almondia.meca.card.domain.vo.Question;
 import com.almondia.meca.card.domain.vo.Title;
 import com.almondia.meca.common.domain.vo.Id;
 
-import io.jsonwebtoken.lang.Assert;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -30,7 +29,7 @@ import lombok.ToString;
 @ToString
 public final class CardSnapShot {
 
-	@AttributeOverride(name = "title", column = @Column(name = "card_title", nullable = false, length = 120))
+	@AttributeOverride(name = "uuid", column = @Column(name = "card_member_id", nullable = false, length = 120))
 	private Id memberId;
 	@AttributeOverride(name = "title", column = @Column(name = "card_title", nullable = false, length = 120))
 	private Title title;
@@ -44,7 +43,7 @@ public final class CardSnapShot {
 	@Enumerated(EnumType.STRING)
 	private CardType cardType;
 
-	@AttributeOverride(name = "description", column = @Column(name = "card_description", nullable = false, length = 2_1000, columnDefinition = "TEXT"))
+	@AttributeOverride(name = "description", column = @Column(name = "card_description", length = 2_1000, columnDefinition = "TEXT"))
 	private Description description;
 
 	@Column(name = "card_created_at", nullable = false, updatable = false)
@@ -64,10 +63,6 @@ public final class CardSnapShot {
 		LocalDateTime createdAt,
 		LocalDateTime modifiedAt
 	) {
-		Assert.noNullElements(
-			new Object[] {memberId, title, question, answer, cardType, description, createdAt,
-				modifiedAt},
-			"CardSnapShot must not be null");
 		this.memberId = memberId;
 		this.title = title;
 		this.question = question;


### PR DESCRIPTION
세부 사항:
- memberId의 제원이 정확히 반영되도록 수정
- description이 null을 허용하도록 attribute 수정