### PR TITLE
refactor/#195: 엔티티 속성 개선

### DIFF
--- a/default-dependencies.gradle
+++ b/default-dependencies.gradle
@@ -29,6 +29,10 @@ dependencies {
     // db
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.mysql:mysql-connector-j'
+    implementation('com.oracle.database.jdbc:ojdbc8-production:21.9.0.0') {
+        exclude group: 'com.oracle.database.ha', module: 'simplefan'
+        exclude group: 'com.oracle.database.ha', module: 'ons'
+    }
 
     // lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/almondia/meca/card/domain/entity/Card.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/Card.java
@@ -38,7 +38,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class Card extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "uuid", column = @Column(name = "card_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "card_id", nullable = false, length = 16))
 	private Id cardId;
 
 	@Embedded
@@ -50,11 +50,11 @@ public abstract class Card extends DateEntity {
 	private Title title;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, length = 16))
 	private Id categoryId;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, length = 16))
 	private Id memberId;
 
 	@Column(name = "images", length = 1020)
@@ -62,7 +62,7 @@ public abstract class Card extends DateEntity {
 	private List<Image> images;
 
 	@Embedded
-	@AttributeOverride(name = "description", column = @Column(name = "description", length = 2_1000, columnDefinition = "TEXT"))
+	@AttributeOverride(name = "description", column = @Column(name = "description", length = 2_1000))
 	private Description description;
 
 	@Transient

--- a/src/main/java/com/almondia/meca/card/domain/entity/Card.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/Card.java
@@ -42,7 +42,7 @@ public abstract class Card extends DateEntity {
 	private Id cardId;
 
 	@Embedded
-	@AttributeOverride(name = "question", column = @Column(name = "question", nullable = false, length = 500))
+	@AttributeOverride(name = "question", column = @Column(name = "question", nullable = false, length = 2000))
 	private Question question;
 
 	@Embedded

--- a/src/main/java/com/almondia/meca/card/domain/entity/EssayCard.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/EssayCard.java
@@ -1,5 +1,7 @@
 package com.almondia.meca.card.domain.entity;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -22,6 +24,7 @@ import lombok.experimental.SuperBuilder;
 public class EssayCard extends Card {
 
 	@Embedded
+	@AttributeOverride(name = "essayAnswer", column = @Column(name = "essay_answer", length = 2000))
 	private EssayAnswer essayAnswer;
 
 	@Override

--- a/src/main/java/com/almondia/meca/card/domain/vo/Description.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/Description.java
@@ -1,6 +1,7 @@
 package com.almondia.meca.card.domain.vo;
 
 import javax.persistence.Embeddable;
+import javax.persistence.Lob;
 
 import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
 
@@ -15,6 +16,7 @@ public class Description implements Wrapper {
 
 	private static final int MAX_LENGTH = 2_1000;
 
+	@Lob
 	private String description;
 
 	public Description(String description) {

--- a/src/main/java/com/almondia/meca/card/domain/vo/EssayAnswer.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/EssayAnswer.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EssayAnswer implements Wrapper {
 
-	private static final int MAX_LENGTH = 255;
+	private static final int MAX_LENGTH = 500;
 
 	private String essayAnswer;
 

--- a/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
@@ -34,15 +34,15 @@ import lombok.NoArgsConstructor;
 public class CardHistory {
 
 	@EmbeddedId
-	@AttributeOverride(name = "uuid", column = @Column(name = "card_history_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "card_history_id", nullable = false, length = 16))
 	private Id cardHistoryId;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "solved_user_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "solved_user_id", nullable = false, length = 16))
 	private Id solvedMemberId;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "card_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "card_id", nullable = false, length = 16))
 	private Id cardId;
 
 	@Embedded

--- a/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
@@ -46,7 +46,7 @@ public class CardHistory {
 	private Id cardId;
 
 	@Embedded
-	@AttributeOverride(name = "answer", column = @Column(name = "user_answer", nullable = false))
+	@AttributeOverride(name = "answer", column = @Column(name = "user_answer", nullable = false, length = 2000))
 	private Answer userAnswer;
 
 	@Embedded

--- a/src/main/java/com/almondia/meca/cardhistory/domain/vo/Answer.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/vo/Answer.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Answer implements Wrapper {
 
-	private static final int MAX_LENGTH = 255;
+	private static final int MAX_LENGTH = 500;
 
 	private String answer;
 

--- a/src/main/java/com/almondia/meca/cardhistory/domain/vo/CardSnapShot.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/vo/CardSnapShot.java
@@ -29,21 +29,21 @@ import lombok.ToString;
 @ToString
 public final class CardSnapShot {
 
-	@AttributeOverride(name = "uuid", column = @Column(name = "card_member_id", nullable = false, length = 120))
+	@AttributeOverride(name = "uuid", column = @Column(name = "card_member_id", nullable = false, length = 16))
 	private Id memberId;
 	@AttributeOverride(name = "title", column = @Column(name = "card_title", nullable = false, length = 120))
 	private Title title;
 
-	@AttributeOverride(name = "question", column = @Column(name = "card_question", nullable = false, length = 500))
+	@AttributeOverride(name = "question", column = @Column(name = "card_question", nullable = false, length = 2000))
 	private Question question;
 
-	@AttributeOverride(name = "answer", column = @Column(name = "card_answer", nullable = false))
+	@AttributeOverride(name = "answer", column = @Column(name = "card_answer", nullable = false, length = 2000))
 	private String answer;
 
 	@Enumerated(EnumType.STRING)
 	private CardType cardType;
 
-	@AttributeOverride(name = "description", column = @Column(name = "card_description", length = 2_1000, columnDefinition = "TEXT"))
+	@AttributeOverride(name = "description", column = @Column(name = "card_description", length = 2_1000))
 	private Description description;
 
 	@Column(name = "card_created_at", nullable = false, updatable = false)

--- a/src/main/java/com/almondia/meca/category/domain/entity/Category.java
+++ b/src/main/java/com/almondia/meca/category/domain/entity/Category.java
@@ -23,7 +23,7 @@ import lombok.experimental.SuperBuilder;
 public class Category extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, length = 16))
 	private Id categoryId;
 
 	@Embedded
@@ -31,7 +31,7 @@ public class Category extends DateEntity {
 	private Title title;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, length = 16))
 	private Id memberId;
 
 	@Embedded

--- a/src/main/java/com/almondia/meca/member/domain/entity/Member.java
+++ b/src/main/java/com/almondia/meca/member/domain/entity/Member.java
@@ -35,22 +35,22 @@ public class Member extends DateEntity {
 	private String oauthId;
 
 	@Embedded
-	@AttributeOverride(name = "name", column = @Column(name = "name", nullable = false, columnDefinition = "VARCHAR(40)"))
+	@AttributeOverride(name = "name", column = @Column(name = "name", nullable = false, length = 60))
 	private Name name;
 
 	@Embedded
-	@AttributeOverride(name = "email", column = @Column(name = "email", columnDefinition = "VARCHAR(255)"))
+	@AttributeOverride(name = "email", column = @Column(name = "email"))
 	private Email email;
 
 	@Embedded
-	@AttributeOverride(name = "image", column = @Column(name = "profile", columnDefinition = "VARCHAR(255)"))
+	@AttributeOverride(name = "image", column = @Column(name = "profile"))
 	private Image profile;
 
-	@Column(name = "o_auth_type", nullable = false, columnDefinition = "VARCHAR(10)")
+	@Column(name = "o_auth_type", nullable = false, length = 10)
 	private OAuthType oAuthType;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "role", nullable = false, columnDefinition = "VARCHAR(10)")
+	@Column(name = "role", nullable = false, length = 10)
 	private Role role;
 
 	private boolean isDeleted;

--- a/src/main/java/com/almondia/meca/member/domain/entity/Member.java
+++ b/src/main/java/com/almondia/meca/member/domain/entity/Member.java
@@ -28,7 +28,7 @@ import lombok.experimental.SuperBuilder;
 public class Member extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, length = 16))
 	private Id memberId;
 
 	@Column(name = "oauth_id", nullable = false, unique = true)

--- a/src/main/java/com/almondia/meca/recommand/domain/entity/CategoryRecommend.java
+++ b/src/main/java/com/almondia/meca/recommand/domain/entity/CategoryRecommend.java
@@ -21,15 +21,15 @@ import lombok.experimental.SuperBuilder;
 public class CategoryRecommend extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "uuid", column = @Column(name = "category_recommend_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "category_recommend_id", nullable = false, length = 16))
 	private Id categoryRecommendId;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, length = 16))
 	private Id categoryId;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "recommend__member_id", nullable = false, columnDefinition = "BINARY(16)"))
+	@AttributeOverride(name = "uuid", column = @Column(name = "recommend__member_id", nullable = false, length = 16))
 	private Id recommendMemberId;
 
 	private boolean isDeleted;

--- a/src/test/java/com/almondia/meca/cardhistory/domain/vo/AnswerTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/domain/vo/AnswerTest.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.Test;
 class AnswerTest {
 
 	@Test
-	@DisplayName("길이가 255 초과시 예외 발생")
-	void shouldThrowWhenLengthMoreThan20Test() {
-		assertThatThrownBy(() -> new Answer("a".repeat(256))).isInstanceOf(IllegalArgumentException.class);
+	@DisplayName("길이가 500 초과시 예외 발생")
+	void shouldThrowWhenLengthMoreThan500Test() {
+		assertThatThrownBy(() -> new Answer("a".repeat(501))).isInstanceOf(IllegalArgumentException.class);
 	}
 
 }


### PR DESCRIPTION
## 요약

- 어떤 DBMS든지 사용 가능하도록 유연하게 코드 개선
    -  mysql, oracle db 사용 가능
    - 특정 DBMS에 종속이 되는 columnDefinition 제거 