### PR TITLE
refactor/#208: 카드 엔티티 수정

### DIFF
--- a/src/main/java/com/almondia/meca/card/domain/entity/Card.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/Card.java
@@ -42,7 +42,7 @@ public abstract class Card extends DateEntity {
 	private Id cardId;
 
 	@Embedded
-	@AttributeOverride(name = "question", column = @Column(name = "question", nullable = false, length = 2000))
+	@AttributeOverride(name = "question", column = @Column(name = "question", nullable = false, length = 5_1000))
 	private Question question;
 
 	@Embedded
@@ -62,7 +62,7 @@ public abstract class Card extends DateEntity {
 	private List<Image> images;
 
 	@Embedded
-	@AttributeOverride(name = "description", column = @Column(name = "description", length = 2_1000))
+	@AttributeOverride(name = "description", column = @Column(name = "description", length = 5_1000))
 	private Description description;
 
 	@Transient

--- a/src/main/java/com/almondia/meca/card/domain/vo/Description.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/Description.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Description implements Wrapper {
 
-	private static final int MAX_LENGTH = 2_1000;
+	private static final int MAX_LENGTH = 51_000;
 
 	@Lob
 	private String description;

--- a/src/main/java/com/almondia/meca/card/domain/vo/Question.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/Question.java
@@ -1,6 +1,7 @@
 package com.almondia.meca.card.domain.vo;
 
 import javax.persistence.Embeddable;
+import javax.persistence.Lob;
 
 import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
 
@@ -13,7 +14,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question implements Wrapper {
 
-	private static final int MAX_LENGTH = 500;
+	private static final int MAX_LENGTH = 51_000;
+
+	@Lob
 	private String question;
 
 	public Question(String question) {

--- a/src/main/java/com/almondia/meca/cardhistory/domain/vo/CardSnapShot.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/vo/CardSnapShot.java
@@ -34,7 +34,7 @@ public final class CardSnapShot {
 	@AttributeOverride(name = "title", column = @Column(name = "card_title", nullable = false, length = 120))
 	private Title title;
 
-	@AttributeOverride(name = "question", column = @Column(name = "card_question", nullable = false, length = 2000))
+	@AttributeOverride(name = "question", column = @Column(name = "card_question", nullable = false, length = 5_1000))
 	private Question question;
 
 	@AttributeOverride(name = "answer", column = @Column(name = "card_answer", nullable = false, length = 2000))
@@ -43,7 +43,7 @@ public final class CardSnapShot {
 	@Enumerated(EnumType.STRING)
 	private CardType cardType;
 
-	@AttributeOverride(name = "description", column = @Column(name = "card_description", length = 2_1000))
+	@AttributeOverride(name = "description", column = @Column(name = "card_description", length = 5_1000))
 	private Description description;
 
 	@Column(name = "card_created_at", nullable = false, updatable = false)

--- a/src/test/java/com/almondia/meca/card/domain/vo/DescriptionTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/vo/DescriptionTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * editText의 길이가 2_1000을 초과하면 IllegalArgumentException을 던진다
- * editText의 길이가 2_1000을 초과하지 않으면 정상적으로 데이터를 생성한다
+ * editText의 길이가 5_1000을 초과하면 IllegalArgumentException을 던진다
+ * editText의 길이가 5_1000을 초과하지 않으면 정상적으로 데이터를 생성한다
  * equalsandhashcode 테스트
  * of 메서드 인스턴스 테스트
  */
@@ -15,12 +15,12 @@ class DescriptionTest {
 
 	@Test
 	void editTextLengthIsOver2_1000Test() {
-		assertThrows(IllegalArgumentException.class, () -> new Description("a".repeat(2_1001)));
+		assertThrows(IllegalArgumentException.class, () -> new Description("a".repeat(5_1001)));
 	}
 
 	@Test
 	void editTextLengthIsNotOver2_1000Test() {
-		assertDoesNotThrow(() -> new Description("a".repeat(2_1000)));
+		assertDoesNotThrow(() -> new Description("a".repeat(5_1000)));
 	}
 
 	@Test

--- a/src/test/java/com/almondia/meca/card/domain/vo/QuestionTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/vo/QuestionTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * 문제를 공배으로 비워 둘 수 없습니다
- * 500자 이상 입력할 수 없습니다
+ * 5만 천자 이상 입력할 수 없습니다
  * of 인스턴스 테스트
  */
 class QuestionTest {
@@ -20,9 +20,9 @@ class QuestionTest {
 	}
 
 	@Test
-	@DisplayName("500자 이상 입력할 수 없습니다")
+	@DisplayName("4만 천자 이상 입력할 수 없습니다")
 	void shouldThrowMoreThan500() {
-		String input = "a".repeat(501);
+		String input = "a".repeat(51_001);
 		assertThatThrownBy(() -> new Question(input)).isInstanceOf(IllegalArgumentException.class);
 	}
 


### PR DESCRIPTION
## 요약

- question, description 필드 최대 저장 길이 51,000자로 수정
- 카드 히스토리의 카드 스냅샷의 속성도 동일하게 수정