### PR TITLE
refactor/#213: 대소문자 구분없이 keywordAnswer 채점하도록 개선하기

### DIFF
--- a/src/main/java/com/almondia/meca/card/domain/vo/KeywordAnswer.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/KeywordAnswer.java
@@ -42,6 +42,13 @@ public class KeywordAnswer implements Wrapper {
 		return keywords.contains(keyword.trim());
 	}
 
+	public boolean containsIgnoreCase(String keyword) {
+		if (keywords == null) {
+			makeKeywords();
+		}
+		return keywords.stream().anyMatch(keyword::equalsIgnoreCase);
+	}
+
 	@Override
 	public String toString() {
 		return keywordAnswer;

--- a/src/main/java/com/almondia/meca/card/domain/vo/MultiChoiceAnswer.java
+++ b/src/main/java/com/almondia/meca/card/domain/vo/MultiChoiceAnswer.java
@@ -27,6 +27,10 @@ public class MultiChoiceAnswer implements Wrapper {
 		return new MultiChoiceAnswer(Integer.parseInt(number));
 	}
 
+	public String getText() {
+		return number.toString();
+	}
+
 	@Override
 	public String toString() {
 		return number.toString();

--- a/src/main/java/com/almondia/meca/cardhistory/domain/service/DefaultScoringMachine.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/service/DefaultScoringMachine.java
@@ -54,7 +54,7 @@ public class DefaultScoringMachine implements ScoringMachine {
 
 	private Score scoringKeywordCard(KeywordCard card, Answer userAnswer) {
 		KeywordAnswer keywordAnswer = card.getKeywordAnswer();
-		if (keywordAnswer.contains(userAnswer.getText())) {
+		if (keywordAnswer.containsIgnoreCase(userAnswer.getText())) {
 			return new Score(100);
 		}
 		return new Score(0);

--- a/src/main/java/com/almondia/meca/cardhistory/domain/service/DefaultScoringMachine.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/service/DefaultScoringMachine.java
@@ -62,7 +62,7 @@ public class DefaultScoringMachine implements ScoringMachine {
 
 	private Score scoringMultiChoiceCard(MultiChoiceCard multiChoiceCard, Answer userAnswer) {
 		MultiChoiceAnswer multiChoiceAnswer = multiChoiceCard.getMultiChoiceAnswer();
-		if (multiChoiceAnswer.toString().equals(userAnswer.getText())) {
+		if (multiChoiceAnswer.getText().equals(userAnswer.getText())) {
 			return new Score(100);
 		}
 		return new Score(0);

--- a/src/test/java/com/almondia/meca/card/domain/vo/KeywordAnswerTest.java
+++ b/src/test/java/com/almondia/meca/card/domain/vo/KeywordAnswerTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * 1. keyword는 500 길이 이상 입력할 수 없습니다
+ *
  */
 class KeywordAnswerTest {
 
@@ -14,6 +14,13 @@ class KeywordAnswerTest {
 	@DisplayName("keyword는 500 길이 이상 입력할 수 없습니다")
 	void validationTest() {
 		assertThatThrownBy(() -> new KeywordAnswer("a".repeat(501))).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("키워드 응답 내에 containIgnoreCase 호출시 대소문자 구분 없이 키워드가 포함되어 있는지 확인한다")
+	void containsIgnoreCaseTest() {
+		KeywordAnswer keywordAnswer = new KeywordAnswer("test,power,energy");
+		assertThat(keywordAnswer.containsIgnoreCase("TEST")).isTrue();
 	}
 
 	@Test

--- a/src/test/java/com/almondia/meca/cardhistory/domain/service/DefaultScoringMachineTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/domain/service/DefaultScoringMachineTest.java
@@ -27,6 +27,7 @@ import com.almondia.meca.helper.CardTestHelper;
  * 카드 타입이 OX_QUIZ인 경우 오답이면 0점을 출력한다
  * 카드 타입이 KEYWORD인 경우 정답이면 100점을 출력한다
  * 카드 타입이 KEYWORD인 경우 오답이면 0점을 출력한다
+ * 카드 타입이 KEYWORD인 경우 대소문자와 관계없이 정답이면 100점을 출력한다
  * 카드 타입이 MULTI_CHOICE인 경우 정답이면 100점을 출력한다
  * 카드 타입이 MULTI_CHOICE인 경우 오답이면 0점을 출력한다
  * 카드 타입이 ESSAY인 경우 형태소에서 가져온 데이터가 없다면 0점을 출력한다
@@ -103,6 +104,19 @@ class DefaultScoringMachineTest {
 
 		// then
 		assertThat(score).isEqualTo(new Score(0));
+	}
+
+	@Test
+	@DisplayName("카드 타입이 KEYWORD인 경우 대소문자와 관계없이 정답이면 100점을 출력한다")
+	void shouldReturnScore100IfCardTypeIsKeywordAndAnswerIsCorrectRegardlessOfCase() {
+		// given
+		Card keywordCard = CardTestHelper.genKeywordCard(Id.generateNextId(), Id.generateNextId(), Id.generateNextId());
+		keywordCard.changeAnswer("keyword,keyMap");
+		// when
+		Score score = scoringMachine.giveScore(morphemeAnalyzer, keywordCard, new Answer("KEYWORD"));
+
+		// then
+		assertThat(score).isEqualTo(new Score(100));
 	}
 
 	@Test

--- a/src/test/java/com/almondia/meca/cardhistory/domain/service/DefaultScoringMachineTest.java
+++ b/src/test/java/com/almondia/meca/cardhistory/domain/service/DefaultScoringMachineTest.java
@@ -163,11 +163,11 @@ class DefaultScoringMachineTest {
 
 	@Test
 	@DisplayName("카드 타입이 ESSAY인 경우 정답이면 100점을 출력한다")
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	void shouldReturnScoreOneHundredIfCardTypeIsEssayAndAnswerIsCorrect() {
 		// given
 		Card essayCard = CardTestHelper.genEssayCard(Id.generateNextId(), Id.generateNextId(), Id.generateNextId());
-		Morphemes tokenMorphemes = new Morphemes(List.of(new EngNlpToken("answer", "NNP")),
+		Morphemes tokenMorphemes = new Morphemes<>(List.of(new EngNlpToken("answer", "NNP")),
 			List.of(new EngNlpToken("answer", "NNP")));
 		Mockito.when(morphemeAnalyzer.analyze(any(), any()))
 			.thenReturn(tokenMorphemes);
@@ -181,11 +181,11 @@ class DefaultScoringMachineTest {
 
 	@Test
 	@DisplayName("카드 타입이 ESSAY인 경우 오답이면 0점을 출력한다")
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	void shouldReturnScoreZeroIfCardTypeIsEssayAndAnswerIsIncorrect() {
 		// given
 		Card essayCard = CardTestHelper.genEssayCard(Id.generateNextId(), Id.generateNextId(), Id.generateNextId());
-		Morphemes tokenMorphemes = new Morphemes(List.of(new EngNlpToken("answer", "NNP")),
+		Morphemes tokenMorphemes = new Morphemes<>(List.of(new EngNlpToken("answer", "NNP")),
 			List.of(new EngNlpToken("aqw", "NNP")));
 		Mockito.when(morphemeAnalyzer.analyze(any(), any()))
 			.thenReturn(tokenMorphemes);


### PR DESCRIPTION
## 요약

- ScoringMachine 테스트 코드의 rawtypes와 unchecked 경고를 무시하도록 어노테이션 설정
- 채점시 keyword 정답의 대소문자에 구분없이 채점하도록 수정
- vo에 containsIgnoreCase 메서드 추가