### PR TITLE
fix/#220: cardHistory 엔티티의 userAnswer null 허용하도록 수정

### DIFF
--- a/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
@@ -46,7 +46,7 @@ public class CardHistory {
 	private Id cardId;
 
 	@Embedded
-	@AttributeOverride(name = "answer", column = @Column(name = "user_answer", nullable = false, length = 2000))
+	@AttributeOverride(name = "answer", column = @Column(name = "user_answer", length = 2000))
 	private Answer userAnswer;
 
 	@Embedded


### PR DESCRIPTION
## 요약

- card_history / user_answer : not null -> null