### PR TITLE
fix/#232: 카드 시뮬레이션 이전 카드 조회 로직 개선

### DIFF
--- a/src/main/java/com/almondia/meca/card/application/CardSimulationService.java
+++ b/src/main/java/com/almondia/meca/card/application/CardSimulationService.java
@@ -59,9 +59,15 @@ public class CardSimulationService {
 		if (!categoryRepository.existsByCategoryIdAndIsDeletedFalse(categoryId)) {
 			throw new IllegalArgumentException("존재하지 않는 카테고리입니다");
 		}
+		List<Card> cards = cardRepository.findByCategoryIdAndIsDeleted(categoryId, false);
 		Map<Id, Double> cardScores = cardHistoryRepository.findCardScoreAvgMapByCategoryId(categoryId);
 		Map<Double, Long> counts = cardScores.entrySet().stream()
 			.collect(Collectors.groupingBy(Map.Entry::getValue, Collectors.counting()));
+		for (Card card : cards) {
+			if (!cardScores.containsKey(card.getCardId())) {
+				counts.put(0.0, counts.getOrDefault(cardScores.get(card.getCardId()), 0L) + 1);
+			}
+		}
 		return counts.entrySet().stream()
 			.map(entry -> new CardCountGroupByScoreDto(entry.getKey(), entry.getValue()))
 			.sorted((o1, o2) -> Double.compare(o2.getScore(), o1.getScore()))

--- a/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepository.java
+++ b/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepository.java
@@ -30,7 +30,8 @@ public interface CardHistoryQueryDslRepository {
 	Map<Id, Pair<Double, Long>> findCardHistoryScoresAvgAndCountsByCategoryIds(List<Id> categoryIds);
 
 	/**
-	 * 카드 ID들의 정보를 이용해 카드 히스토리 통계와 카드 히스토리 갯수를 쿼리함
+	 * 카드 ID들의 정보를 이용해 카드 히스토리 통계와 카드 히스토리 갯수를 쿼리함.
+	 * cardId의 카드 히스토리 정보가 없는 경우 Pair(0.0, 0L)으로 초기화 함.
 	 *
 	 * @param cardIds 조회할 카드 리스트
 	 * @return 카드 아이디를 키로 하는 카드 히스토리 통계와 카드 히스토리 갯수

--- a/src/test/java/com/almondia/meca/card/application/CardSimulationServiceTest.java
+++ b/src/test/java/com/almondia/meca/card/application/CardSimulationServiceTest.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 import javax.persistence.EntityManager;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,6 +22,7 @@ import org.springframework.security.access.AccessDeniedException;
 
 import com.almondia.meca.card.controller.dto.CardCountGroupByScoreDto;
 import com.almondia.meca.card.controller.dto.CardDto;
+import com.almondia.meca.card.domain.entity.Card;
 import com.almondia.meca.card.domain.repository.CardRepository;
 import com.almondia.meca.cardhistory.domain.repository.CardHistoryRepository;
 import com.almondia.meca.category.domain.entity.Category;
@@ -168,56 +168,49 @@ class CardSimulationServiceTest {
 		@DisplayName("삭제된 카테고리를 조회한 경우")
 		void shouldThrowIllegalArgumentExceptionWhenCategoryIsDeletedTest() {
 			// given
-			Mockito.doReturn(Optional.empty())
-				.when(categoryRepository)
-				.findByCategoryIdAndIsDeleted(any(), anyBoolean());
-			Mockito.doReturn(
-					List.of(CardTestHelper.genOxCard(Id.generateNextId(), Id.generateNextId(), Id.generateNextId())))
-				.when(cardRepository)
-				.findByCategoryIdAndIsDeleted(any(), anyBoolean());
-			Id categoryId = Id.generateNextId();
 			Id memberId = Id.generateNextId();
+			Id categoryId = Id.generateNextId();
+			Category category = CategoryTestHelper.generateUnSharedCategory("title", memberId,
+				categoryId);
+			category.delete();
+			em.persist(category);
 
 			// expect
 			assertThatThrownBy(
-				() -> cardSimulationService.simulateScore(categoryId, memberId, 100)).isInstanceOf(
-				IllegalArgumentException.class);
+				() -> cardSimulationService.simulateScore(categoryId, memberId, 100))
+				.isInstanceOf(IllegalArgumentException.class);
+
 		}
 
 		@Test
 		@DisplayName("본인 카테고리가 아니거나 남의 카테고리지만 공유가 되지 않은 경우 접근 불가 예외를 발생한다")
 		void shouldThrowAccessDeniedExceptionWhenNotMyCategoryOrNotSharedTest() {
 			// given
-			Mockito.doReturn(Optional.of(
-					CategoryTestHelper.generateUnSharedCategory("title", Id.generateNextId(), Id.generateNextId())))
-				.when(categoryRepository)
-				.findByCategoryIdAndIsDeleted(any(), anyBoolean());
-			Mockito.doReturn(
-					List.of(CardTestHelper.genOxCard(Id.generateNextId(), Id.generateNextId(), Id.generateNextId())))
-				.when(cardRepository)
-				.findCardByCategoryIdScoreAsc(any(), anyInt());
-			Id categoryId = Id.generateNextId();
 			Id memberId = Id.generateNextId();
+			Id categoryId = Id.generateNextId();
+			Id otherMemberId = Id.generateNextId();
+			Category category = CategoryTestHelper.generateUnSharedCategory("title", memberId,
+				categoryId);
+			em.persist(category);
 
 			// expect
 			assertThatThrownBy(
-				() -> cardSimulationService.simulateScore(categoryId, memberId, 100)).isInstanceOf(
-				AccessDeniedException.class);
+				() -> cardSimulationService.simulateScore(categoryId, otherMemberId, 100))
+				.isInstanceOf(AccessDeniedException.class);
 		}
 
 		@Test
 		@DisplayName("카테고리에 속한 카드가 없는 경우 빈 리스트를 반환한다")
 		void shouldReturnEmptyListWhenCategoryHasNoCardsTest() {
 			// given
-			Mockito.doReturn(Optional.of(
-					CategoryTestHelper.generateSharedCategory("title", Id.generateNextId(), Id.generateNextId())))
-				.when(categoryRepository)
-				.findByCategoryIdAndIsDeleted(any(), anyBoolean());
-			Mockito.doReturn(List.of()).when(cardRepository).findByCategoryIdAndIsDeleted(any(), anyBoolean());
+			Id memberId = Id.generateNextId();
+			Id categoryId = Id.generateNextId();
+			Category category = CategoryTestHelper.generateUnSharedCategory("title", memberId,
+				categoryId);
+			em.persist(category);
 
 			// when
-			List<CardDto> result = cardSimulationService.simulateScore(Id.generateNextId(),
-				Id.generateNextId(), 100);
+			List<CardDto> result = cardSimulationService.simulateScore(categoryId, memberId, 100);
 
 			// then
 			assertThat(result).isEmpty();
@@ -227,19 +220,25 @@ class CardSimulationServiceTest {
 		@DisplayName("limit으로 제한한 카드 갯수로 출력한다")
 		void shouldReturnLimitedCardsTest() {
 			// given
-			Mockito.doReturn(Optional.of(
-					CategoryTestHelper.generateSharedCategory("title", Id.generateNextId(), Id.generateNextId())))
-				.when(categoryRepository)
-				.findByCategoryIdAndIsDeleted(any(), anyBoolean());
-			Mockito.doReturn(
-					List.of(CardTestHelper.genOxCard(Id.generateNextId(), Id.generateNextId(), Id.generateNextId()),
-						CardTestHelper.genOxCard(Id.generateNextId(), Id.generateNextId(), Id.generateNextId())))
-				.when(cardRepository).findCardByCategoryIdScoreAsc(any(), anyInt());
-			final int limit = 2;
+			Id memberId = Id.generateNextId();
+			Id categoryId = Id.generateNextId();
+			Id cardId1 = Id.generateNextId();
+			Id cardId2 = Id.generateNextId();
+			Id cardId3 = Id.generateNextId();
+			Category category = CategoryTestHelper.generateUnSharedCategory("title", memberId,
+				categoryId);
+			Card card1 = CardTestHelper.genOxCard(memberId, categoryId, cardId1);
+			Card card2 = CardTestHelper.genOxCard(memberId, categoryId, cardId2);
+			Card card3 = CardTestHelper.genOxCard(memberId, categoryId, cardId3);
+			em.persist(category);
+			em.persist(card1);
+			em.persist(card2);
+			em.persist(card3);
+			int limit = 2;
 
 			// when
-			List<CardDto> result = cardSimulationService.simulateScore(Id.generateNextId(),
-				Id.generateNextId(), limit);
+			List<CardDto> result = cardSimulationService.simulateScore(categoryId,
+				memberId, limit);
 
 			// then
 			assertThat(result).hasSize(limit);
@@ -254,14 +253,17 @@ class CardSimulationServiceTest {
 		@DisplayName("카테고리가 삭제되거나 없는 카테고리면 예외를 발생한다")
 		void shouldThrowIllegalArgumentExceptionWhenCategoryIsDeletedTest() {
 			// given
-			Mockito.doReturn(false)
-				.when(categoryRepository)
-				.existsByCategoryIdAndIsDeletedFalse(any());
-			Id randomId = Id.generateNextId();
+			Id memberId = Id.generateNextId();
+			Id categoryId = Id.generateNextId();
+			Category category = CategoryTestHelper.generateUnSharedCategory("title", memberId,
+				categoryId);
+			category.delete();
+			em.persist(category);
 
 			// expect
-			Assert.assertThrows(IllegalArgumentException.class,
-				() -> cardSimulationService.findCardCountByScore(randomId));
+			assertThatThrownBy(
+				() -> cardSimulationService.findCardCountByScore(categoryId))
+				.isInstanceOf(IllegalArgumentException.class);
 		}
 
 		@Test


### PR DESCRIPTION
## 요약

- 카드 히스토리가 없는 문제의 경우 평균 점수 0점을 기준으로 갯수를 조회함.