### PR TITLE
fix: 0.0 카운트 문제 해결

### DIFF
--- a/src/main/java/com/almondia/meca/card/application/CardSimulationService.java
+++ b/src/main/java/com/almondia/meca/card/application/CardSimulationService.java
@@ -66,7 +66,7 @@ public class CardSimulationService {
 			.collect(Collectors.groupingBy(Map.Entry::getValue, Collectors.counting()));
 		for (Card card : cards) {
 			if (!cardScores.containsKey(card.getCardId())) {
-				counts.put(0.0, counts.getOrDefault(cardScores.get(card.getCardId()), 0L) + 1);
+				counts.put(0.0, counts.getOrDefault(0.0, 0L) + 1);
 			}
 		}
 		return counts.entrySet().stream()

--- a/src/test/java/com/almondia/meca/card/application/CardSimulationServiceTest.java
+++ b/src/test/java/com/almondia/meca/card/application/CardSimulationServiceTest.java
@@ -312,5 +312,30 @@ class CardSimulationServiceTest {
 			assertThat(result.get(0).getCount()).isNotZero();
 		}
 
+		@Test
+		@DisplayName("카드 히스토리가 없거나 평균점수가 0점인 카드는 모두 카운트 가능해야한다")
+		void shouldCountWhenNotHaveCardHistoryAndZeroScoreCardTest() {
+			// given
+			Id categoryId = Id.generateNextId();
+			Id memberId = Id.generateNextId();
+			Id cardId1 = Id.generateNextId();
+			Id cardId2 = Id.generateNextId();
+			Id cardHistoryId = Id.generateNextId();
+			Category category = CategoryTestHelper.generateUnSharedCategory("title", memberId, categoryId);
+			Card card1 = CardTestHelper.genOxCard(memberId, categoryId, cardId1);
+			Card card2 = CardTestHelper.genOxCard(memberId, categoryId, cardId2);
+			CardHistory cardHistory = CardHistoryTestHelper.generateCardHistory(cardHistoryId, cardId1, 0);
+			em.persist(category);
+			em.persist(card1);
+			em.persist(card2);
+			em.persist(cardHistory);
+
+			// when
+			List<CardCountGroupByScoreDto> result = cardSimulationService.findCardCountByScore(categoryId);
+
+			// then
+			assertThat(result.get(0)).extracting("score", "count").containsExactly(0.0, 2L);
+
+		}
 	}
 }


### PR DESCRIPTION
## 요약

- 카드 히스토리가 없는 경우나 평균점수가 0점인 카드를 제대로 카운트 못하는 문제 해결