### PR TITLE
refactor/#246: id 타입 개선

### DIFF
--- a/default-dependencies.gradle
+++ b/default-dependencies.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
-    
+
     // oauth client
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
@@ -54,6 +54,10 @@ dependencies {
 
     // ulid-creator
     implementation group: 'com.github.f4b6a3', name: 'ulid-creator', version: '5.1.0'
+
+    // tsid-creator
+    implementation group: 'com.github.f4b6a3', name: 'tsid-creator', version: '5.2.4'
+
 
     // javax.annotation.meta.When support (JSR305)
     implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/default-dependencies.gradle
+++ b/default-dependencies.gradle
@@ -51,9 +51,7 @@ dependencies {
 
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
-    // ulid-creator
-    implementation group: 'com.github.f4b6a3', name: 'ulid-creator', version: '5.1.0'
+    
 
     // tsid-creator
     implementation group: 'com.github.f4b6a3', name: 'tsid-creator', version: '5.2.4'

--- a/src/main/java/com/almondia/meca/card/domain/entity/Card.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/Card.java
@@ -37,7 +37,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class Card extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "tsid", column = @Column(name = "card_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "card_id", nullable = false))
 	private Id cardId;
 
 	@Embedded
@@ -45,11 +45,11 @@ public abstract class Card extends DateEntity {
 	private Title title;
 
 	@Embedded
-	@AttributeOverride(name = "tsid", column = @Column(name = "category_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "category_id", nullable = false))
 	private Id categoryId;
 
 	@Embedded
-	@AttributeOverride(name = "tsid", column = @Column(name = "member_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "member_id", nullable = false))
 	private Id memberId;
 
 	@Column(name = "images", length = 1020)

--- a/src/main/java/com/almondia/meca/card/domain/entity/Card.java
+++ b/src/main/java/com/almondia/meca/card/domain/entity/Card.java
@@ -37,7 +37,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class Card extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "uuid", column = @Column(name = "card_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "card_id", nullable = false, length = 16))
 	private Id cardId;
 
 	@Embedded
@@ -45,11 +45,11 @@ public abstract class Card extends DateEntity {
 	private Title title;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "category_id", nullable = false, length = 16))
 	private Id categoryId;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "member_id", nullable = false, length = 16))
 	private Id memberId;
 
 	@Column(name = "images", length = 1020)

--- a/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/card/infra/querydsl/CardQueryDslRepositoryImpl.java
@@ -52,7 +52,7 @@ public class CardQueryDslRepositoryImpl implements CardQueryDslRepository {
 				card.isDeleted.eq(false),
 				lessOrEqCardId(lastCardId)
 			)
-			.orderBy(card.cardId.uuid.desc())
+			.orderBy(card.cardId.tsid.desc())
 			.limit(pageSize + 1L)
 			.fetch()
 			.stream()
@@ -165,7 +165,7 @@ public class CardQueryDslRepositoryImpl implements CardQueryDslRepository {
 
 	@Nullable
 	private BooleanExpression lessOrEqCardId(@Nullable Id lastCardId) {
-		return lastCardId == null ? null : card.cardId.uuid.loe(lastCardId.getUuid());
+		return lastCardId == null ? null : card.cardId.tsid.loe(lastCardId.getTsid());
 	}
 
 	@Nullable

--- a/src/main/java/com/almondia/meca/card/infra/querydsl/CardSortField.java
+++ b/src/main/java/com/almondia/meca/card/infra/querydsl/CardSortField.java
@@ -7,7 +7,7 @@ import com.almondia.meca.common.infra.querydsl.SortField;
 import com.querydsl.core.types.dsl.ComparableExpression;
 
 public enum CardSortField implements SortField {
-	CARD_ID("cardId", QCard.card.cardId.uuid),
+	CARD_ID("cardId", QCard.card.cardId.tsid),
 	TITLE("title", QCard.card.title.title),
 	CREATED_AT("createdAt", QCard.card.createdAt),
 	MODIFIED_AT("modifiedAt", QCard.card.modifiedAt);

--- a/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
@@ -34,15 +34,15 @@ import lombok.NoArgsConstructor;
 public class CardHistory {
 
 	@EmbeddedId
-	@AttributeOverride(name = "uuid", column = @Column(name = "card_history_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "card_history_id", nullable = false, length = 16))
 	private Id cardHistoryId;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "solved_user_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "solved_user_id", nullable = false, length = 16))
 	private Id solvedMemberId;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "card_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "card_id", nullable = false, length = 16))
 	private Id cardId;
 
 	@Embedded

--- a/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
+++ b/src/main/java/com/almondia/meca/cardhistory/domain/entity/CardHistory.java
@@ -34,15 +34,15 @@ import lombok.NoArgsConstructor;
 public class CardHistory {
 
 	@EmbeddedId
-	@AttributeOverride(name = "tsid", column = @Column(name = "card_history_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "card_history_id", nullable = false))
 	private Id cardHistoryId;
 
 	@Embedded
-	@AttributeOverride(name = "tsid", column = @Column(name = "solved_user_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "solved_user_id", nullable = false))
 	private Id solvedMemberId;
 
 	@Embedded
-	@AttributeOverride(name = "tsid", column = @Column(name = "card_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "card_id", nullable = false))
 	private Id cardId;
 
 	@Embedded

--- a/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/cardhistory/infra/querydsl/CardHistoryQueryDslRepositoryImpl.java
@@ -45,7 +45,7 @@ public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRep
 			.on(cardHistory.solvedMemberId.eq(member.memberId), member.isDeleted.eq(false))
 			.where(cardHistory.isDeleted.eq(false), cardHistory.cardId.eq(cardId),
 				lessOrEqCardHistoryId(lastCardHistoryId))
-			.orderBy(cardHistory.cardHistoryId.uuid.desc())
+			.orderBy(cardHistory.cardHistoryId.tsid.desc())
 			.limit(pageSize + 1L)
 			.fetch();
 
@@ -68,7 +68,7 @@ public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRep
 			.on(cardHistory.solvedMemberId.eq(member.memberId), member.isDeleted.eq(false))
 			.where(cardHistory.solvedMemberId.eq(solvedMemberId), cardHistory.isDeleted.eq(false),
 				lessOrEqCardHistoryId(lastCardHistoryId))
-			.orderBy(cardHistory.cardHistoryId.uuid.desc())
+			.orderBy(cardHistory.cardHistoryId.tsid.desc())
 			.limit(pageSize + 1L)
 			.fetch();
 
@@ -178,6 +178,6 @@ public class CardHistoryQueryDslRepositoryImpl implements CardHistoryQueryDslRep
 
 	@Nullable
 	private BooleanExpression lessOrEqCardHistoryId(@Nullable Id lastCardHistoryId) {
-		return lastCardHistoryId == null ? null : cardHistory.cardHistoryId.uuid.loe(lastCardHistoryId.getUuid());
+		return lastCardHistoryId == null ? null : cardHistory.cardHistoryId.tsid.loe(lastCardHistoryId.getTsid());
 	}
 }

--- a/src/main/java/com/almondia/meca/category/domain/entity/Category.java
+++ b/src/main/java/com/almondia/meca/category/domain/entity/Category.java
@@ -23,7 +23,7 @@ import lombok.experimental.SuperBuilder;
 public class Category extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "category_id", nullable = false, length = 16))
 	private Id categoryId;
 
 	@Embedded
@@ -31,7 +31,7 @@ public class Category extends DateEntity {
 	private Title title;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "member_id", nullable = false, length = 16))
 	private Id memberId;
 
 	@Embedded

--- a/src/main/java/com/almondia/meca/category/domain/entity/Category.java
+++ b/src/main/java/com/almondia/meca/category/domain/entity/Category.java
@@ -23,7 +23,7 @@ import lombok.experimental.SuperBuilder;
 public class Category extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "tsid", column = @Column(name = "category_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "category_id", nullable = false))
 	private Id categoryId;
 
 	@Embedded
@@ -31,7 +31,7 @@ public class Category extends DateEntity {
 	private Title title;
 
 	@Embedded
-	@AttributeOverride(name = "tsid", column = @Column(name = "member_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "member_id", nullable = false))
 	private Id memberId;
 
 	@Embedded

--- a/src/main/java/com/almondia/meca/category/infra/querydsl/CategoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/almondia/meca/category/infra/querydsl/CategoryQueryDslRepositoryImpl.java
@@ -35,8 +35,8 @@ public class CategoryQueryDslRepositoryImpl implements CategoryQueryDslRepositor
 		return jpaQueryFactory.selectFrom(category)
 			.where(isShared(shared), category.isDeleted.eq(false), dynamicCursorExpression(lastCategoryId),
 				containTitle(categorySearchOption.getContainTitle()))
-			.orderBy(category.categoryId.uuid.desc())
-			.limit(pageSize + 1)
+			.orderBy(category.categoryId.tsid.desc())
+			.limit(pageSize + 1L)
 			.fetch();
 	}
 
@@ -46,8 +46,8 @@ public class CategoryQueryDslRepositoryImpl implements CategoryQueryDslRepositor
 		return jpaQueryFactory.selectFrom(category)
 			.where(isShared(shared), category.memberId.eq(memberId), category.isDeleted.eq(false),
 				dynamicCursorExpression(lastCategoryId), containTitle(categorySearchOption.getContainTitle()))
-			.orderBy(category.categoryId.uuid.desc())
-			.limit(pageSize + 1)
+			.orderBy(category.categoryId.tsid.desc())
+			.limit(pageSize + 1L)
 			.fetch();
 	}
 
@@ -61,8 +61,8 @@ public class CategoryQueryDslRepositoryImpl implements CategoryQueryDslRepositor
 				categoryRecommend.recommendMemberId.eq(IdWhoRecommend))
 			.where(category.isShared.eq(true), category.isDeleted.eq(false), dynamicCursorExpression(lastCategoryId),
 				containTitle(categorySearchOption.getContainTitle()))
-			.orderBy(category.categoryId.uuid.desc())
-			.limit(pageSize + 1)
+			.orderBy(category.categoryId.tsid.desc())
+			.limit(pageSize + 1L)
 			.fetch();
 	}
 
@@ -73,14 +73,13 @@ public class CategoryQueryDslRepositoryImpl implements CategoryQueryDslRepositor
 	private BooleanExpression isShared(Boolean shared) {
 		if (shared == null) {
 			return null;
-		}
-		if (shared) {
+		} else if (shared) {
 			return category.isShared.eq(true);
 		}
 		return category.isShared.eq(false);
 	}
 
 	private BooleanExpression dynamicCursorExpression(Id lastCategoryId) {
-		return lastCategoryId == null ? null : category.categoryId.uuid.loe(lastCategoryId.getUuid());
+		return lastCategoryId == null ? null : category.categoryId.tsid.loe(lastCategoryId.getTsid());
 	}
 }

--- a/src/main/java/com/almondia/meca/common/configuration/jackson/module/wrapper/WrapperSerializer.java
+++ b/src/main/java/com/almondia/meca/common/configuration/jackson/module/wrapper/WrapperSerializer.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.github.f4b6a3.tsid.Tsid;
 
 public class WrapperSerializer extends StdSerializer<Wrapper> {
 
@@ -45,6 +46,9 @@ public class WrapperSerializer extends StdSerializer<Wrapper> {
 				gen.writeString((String)o);
 			}
 			if (o instanceof UUID) {
+				gen.writeString(o.toString());
+			}
+			if (o instanceof Tsid) {
 				gen.writeString(o.toString());
 			}
 			if (o instanceof Double) {

--- a/src/main/java/com/almondia/meca/common/configuration/jackson/module/wrapper/WrapperSerializer.java
+++ b/src/main/java/com/almondia/meca/common/configuration/jackson/module/wrapper/WrapperSerializer.java
@@ -49,7 +49,7 @@ public class WrapperSerializer extends StdSerializer<Wrapper> {
 				gen.writeString(o.toString());
 			}
 			if (o instanceof Tsid) {
-				gen.writeString(o.toString());
+				gen.writeString(((Tsid)o).toLowerCase());
 			}
 			if (o instanceof Double) {
 				gen.writeNumber((double)o);

--- a/src/main/java/com/almondia/meca/common/domain/converter/TsidConverter.java
+++ b/src/main/java/com/almondia/meca/common/domain/converter/TsidConverter.java
@@ -1,0 +1,22 @@
+package com.almondia.meca.common.domain.converter;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import com.github.f4b6a3.tsid.Tsid;
+
+@Converter(autoApply = true)
+public class TsidConverter implements AttributeConverter<Tsid, Long> {
+	@Override
+	public Long convertToDatabaseColumn(Tsid attribute) {
+		if (attribute == null) {
+			return null;
+		}
+		return attribute.toLong();
+	}
+
+	@Override
+	public Tsid convertToEntityAttribute(Long dbData) {
+		return dbData == null ? null : Tsid.from(dbData);
+	}
+}

--- a/src/main/java/com/almondia/meca/common/domain/vo/Id.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/Id.java
@@ -1,13 +1,12 @@
 package com.almondia.meca.common.domain.vo;
 
 import java.io.Serializable;
-import java.util.UUID;
 
 import javax.persistence.Embeddable;
 
 import com.almondia.meca.common.configuration.jackson.module.wrapper.Wrapper;
-import com.github.f4b6a3.ulid.Ulid;
-import com.github.f4b6a3.ulid.UlidCreator;
+import com.github.f4b6a3.tsid.Tsid;
+import com.github.f4b6a3.tsid.TsidCreator;
 
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -22,19 +21,19 @@ public class Id implements Serializable, Wrapper, Comparable<Id> {
 
 	private static final long serialVersionUID = -2772995063676474658L;
 
-	private UUID tsid;
+	private Tsid tsid;
 
-	public Id(UUID tsid) {
+	public Id(Tsid tsid) {
 		this.tsid = tsid;
 	}
 
 	public Id(String tsid) {
-		this.tsid = UUID.fromString(tsid);
+		this.tsid = Tsid.from(tsid);
 	}
 
 	public static Id generateNextId() {
-		Ulid ulid = UlidCreator.getMonotonicUlid();
-		return new Id(ulid.toUuid());
+		Tsid tsid = TsidCreator.getTsid();
+		return new Id(tsid);
 	}
 
 	@Override

--- a/src/main/java/com/almondia/meca/common/domain/vo/Id.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/Id.java
@@ -22,14 +22,14 @@ public class Id implements Serializable, Wrapper, Comparable<Id> {
 
 	private static final long serialVersionUID = -2772995063676474658L;
 
-	private UUID uuid;
+	private UUID tsid;
 
-	public Id(UUID uuid) {
-		this.uuid = uuid;
+	public Id(UUID tsid) {
+		this.tsid = tsid;
 	}
 
-	public Id(String uuid) {
-		this.uuid = UUID.fromString(uuid);
+	public Id(String tsid) {
+		this.tsid = UUID.fromString(tsid);
 	}
 
 	public static Id generateNextId() {
@@ -39,11 +39,11 @@ public class Id implements Serializable, Wrapper, Comparable<Id> {
 
 	@Override
 	public String toString() {
-		return uuid.toString();
+		return tsid.toString();
 	}
 
 	@Override
 	public int compareTo(Id o) {
-		return this.uuid.compareTo(o.uuid);
+		return this.tsid.compareTo(o.tsid);
 	}
 }

--- a/src/main/java/com/almondia/meca/common/domain/vo/Id.java
+++ b/src/main/java/com/almondia/meca/common/domain/vo/Id.java
@@ -38,7 +38,7 @@ public class Id implements Serializable, Wrapper, Comparable<Id> {
 
 	@Override
 	public String toString() {
-		return tsid.toString();
+		return tsid.toLowerCase();
 	}
 
 	@Override

--- a/src/main/java/com/almondia/meca/member/domain/entity/Member.java
+++ b/src/main/java/com/almondia/meca/member/domain/entity/Member.java
@@ -28,7 +28,7 @@ import lombok.experimental.SuperBuilder;
 public class Member extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "uuid", column = @Column(name = "member_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "member_id", nullable = false, length = 16))
 	private Id memberId;
 
 	@Column(name = "oauth_id", nullable = false, unique = true)

--- a/src/main/java/com/almondia/meca/member/domain/entity/Member.java
+++ b/src/main/java/com/almondia/meca/member/domain/entity/Member.java
@@ -28,7 +28,7 @@ import lombok.experimental.SuperBuilder;
 public class Member extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "tsid", column = @Column(name = "member_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "member_id", nullable = false))
 	private Id memberId;
 
 	@Column(name = "oauth_id", nullable = false, unique = true)

--- a/src/main/java/com/almondia/meca/recommand/domain/entity/CategoryRecommend.java
+++ b/src/main/java/com/almondia/meca/recommand/domain/entity/CategoryRecommend.java
@@ -21,15 +21,15 @@ import lombok.experimental.SuperBuilder;
 public class CategoryRecommend extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "tsid", column = @Column(name = "category_recommend_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "category_recommend_id", nullable = false))
 	private Id categoryRecommendId;
 
 	@Embedded
-	@AttributeOverride(name = "tsid", column = @Column(name = "category_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "category_id", nullable = false))
 	private Id categoryId;
 
 	@Embedded
-	@AttributeOverride(name = "tsid", column = @Column(name = "recommend__member_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "recommend__member_id", nullable = false))
 	private Id recommendMemberId;
 
 	private boolean isDeleted;

--- a/src/main/java/com/almondia/meca/recommand/domain/entity/CategoryRecommend.java
+++ b/src/main/java/com/almondia/meca/recommand/domain/entity/CategoryRecommend.java
@@ -21,15 +21,15 @@ import lombok.experimental.SuperBuilder;
 public class CategoryRecommend extends DateEntity {
 
 	@EmbeddedId
-	@AttributeOverride(name = "uuid", column = @Column(name = "category_recommend_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "category_recommend_id", nullable = false, length = 16))
 	private Id categoryRecommendId;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "category_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "category_id", nullable = false, length = 16))
 	private Id categoryId;
 
 	@Embedded
-	@AttributeOverride(name = "uuid", column = @Column(name = "recommend__member_id", nullable = false, length = 16))
+	@AttributeOverride(name = "tsid", column = @Column(name = "recommend__member_id", nullable = false, length = 16))
 	private Id recommendMemberId;
 
 	private boolean isDeleted;

--- a/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
+++ b/src/test/java/com/almondia/meca/card/controller/CardControllerTest.java
@@ -391,7 +391,7 @@ class CardControllerTest {
 			CardCursorPageWithCategory cardCursorPageWithCategory = new CardCursorPageWithCategory(cursor);
 			cardCursorPageWithCategory.setCategory(Category.builder()
 				.categoryId(Id.generateNextId())
-				.memberId(new Id("2825b9a9-d89a-4301-99b5-a7668a5b5fff"))
+				.memberId(new Id("0DD59B764XR49"))
 				.thumbnail(Image.of("thumbnail"))
 				.createdAt(LocalDateTime.now())
 				.modifiedAt(LocalDateTime.now())
@@ -399,7 +399,7 @@ class CardControllerTest {
 				.title(new com.almondia.meca.category.domain.vo.Title("title"))
 				.build());
 			cardCursorPageWithCategory.setMember(Member.builder()
-				.memberId(new Id("2825b9a9-d89a-4301-99b5-a7668a5b5fff"))
+				.memberId(new Id("0DD59B764XR49"))
 				.email(new Email("helloworld@naver.com"))
 				.name(Name.of("hello"))
 				.oAuthType(OAuthType.GOOGLE)
@@ -484,7 +484,7 @@ class CardControllerTest {
 			CardCursorPageWithCategory cardCursorPageWithCategory = new CardCursorPageWithCategory(cursor);
 			cardCursorPageWithCategory.setCategory(Category.builder()
 				.categoryId(Id.generateNextId())
-				.memberId(new Id("2825b9a9-d89a-4301-99b5-a7668a5b5fff"))
+				.memberId(new Id("0DD59B764XR49"))
 				.thumbnail(Image.of("thumbnail"))
 				.createdAt(LocalDateTime.now())
 				.modifiedAt(LocalDateTime.now())
@@ -492,7 +492,7 @@ class CardControllerTest {
 				.title(new com.almondia.meca.category.domain.vo.Title("title"))
 				.build());
 			cardCursorPageWithCategory.setMember(Member.builder()
-				.memberId(new Id("2825b9a9-d89a-4301-99b5-a7668a5b5fff"))
+				.memberId(new Id("0DD59B764XR49"))
 				.email(new Email("helloworld@naver.com"))
 				.name(Name.of("hello"))
 				.oAuthType(OAuthType.GOOGLE)

--- a/src/test/java/com/almondia/meca/common/domain/vo/IdTest.java
+++ b/src/test/java/com/almondia/meca/common/domain/vo/IdTest.java
@@ -30,7 +30,6 @@ class IdTest {
 	void serializeTest() throws JsonProcessingException {
 		Id id = Id.generateNextId();
 		String value = objectMapper.writeValueAsString(id);
-		System.out.println(value);
 		assertThat(value).isEqualTo("\"" + id + "\"");
 	}
 

--- a/src/test/java/com/almondia/meca/mock/security/WithMockMember.java
+++ b/src/test/java/com/almondia/meca/mock/security/WithMockMember.java
@@ -19,7 +19,7 @@ import com.almondia.meca.member.domain.vo.Role;
 @WithSecurityContext(factory = WithMockMemberSecurityContextFactory.class)
 public @interface WithMockMember {
 
-	String id() default "0DD59B764XR49";
+	String id() default "0dd59b764xr49";
 
 	String email() default "helloworld@naver.com";
 

--- a/src/test/java/com/almondia/meca/mock/security/WithMockMember.java
+++ b/src/test/java/com/almondia/meca/mock/security/WithMockMember.java
@@ -19,7 +19,7 @@ import com.almondia.meca.member.domain.vo.Role;
 @WithSecurityContext(factory = WithMockMemberSecurityContextFactory.class)
 public @interface WithMockMember {
 
-	String id() default "2825b9a9-d89a-4301-99b5-a7668a5b5fff";
+	String id() default "0DD59B764XR49";
 
 	String email() default "helloworld@naver.com";
 


### PR DESCRIPTION
## 요약

- uuid -> tsid 타입으로 수정
- 클라이언트와 서버간의 id는 문자열(13글자)로  전달함.
- 서버 db에 저장시에는 정수(18글자) 형태로 저장함